### PR TITLE
Decoupled Lighting Uniform Config so that it's in a Different Function

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -21,6 +21,19 @@ void Systems::createModelComponents(ECS &ecs, std::unordered_map<std::string, st
     }
 }
 
+void Systems::setLight(RenderEngine & renderEngine, const ShaderType & shaderType, glm::mat4 view)
+{
+    // Inverse of the view matrix gives the world-to-camera transformation
+    glm::mat4 inverseViewMatrix = glm::inverse(view);
+
+    // The camera's position is the translation part of the inverse view matrix
+    glm::vec3 cameraPosition = glm::vec3(inverseViewMatrix[3]);
+
+    renderEngine.GetShader(shaderType)->SetUniform3f("lightColour", 1.0f, 1.0f, 1.0f);
+    renderEngine.GetShader(shaderType)->SetUniform3f("lightPos", 100.0f, 0.0f, 0.0f);
+    renderEngine.GetShader(shaderType)->SetUniform3f("viewPos", cameraPosition.x, cameraPosition.y, cameraPosition.z);
+}
+
 void Systems::drawModels(const ECS &ecs, const ShaderType & shaderType, RenderEngine & renderEngine, const std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels, glm::mat4 projection, glm::mat4 view)
 {
     auto group = ecs.GetAllEntitiesWith<ModelComponent, TransformComponent>(); //the container with all the matching entities
@@ -43,15 +56,6 @@ void Systems::drawModels(const ECS &ecs, const ShaderType & shaderType, RenderEn
             renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("view", view);
             renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("model", transform);
 
-            // Inverse of the view matrix gives the world-to-camera transformation
-            glm::mat4 inverseViewMatrix = glm::inverse(view);
-
-            // The camera's position is the translation part of the inverse view matrix
-            glm::vec3 cameraPosition = glm::vec3(inverseViewMatrix[3]);
-
-            renderEngine.GetShader(shaderType)->SetUniform3f("lightColour", 1.0f, 1.0f, 1.0f);
-            renderEngine.GetShader(shaderType)->SetUniform3f("lightPos", 100.0f, 0.0f, 0.0f);
-            renderEngine.GetShader(shaderType)->SetUniform3f("viewPos", cameraPosition.x, cameraPosition.y, cameraPosition.z);
             //draw model
             for (unsigned int i = 0; i < sceneModels.at(currentModelComponent.model_path)->GetSubMeshes().size(); i++) {
                 sceneModels.at(currentModelComponent.model_path)->GetSubMeshes()[i]->SetTexture();

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -32,6 +32,14 @@ public:
 
     /**
      *
+     * @param renderEngine
+     * @param shaderType
+     * @param view
+     */
+    void setLight(RenderEngine & renderEngine, const ShaderType & shaderType, glm::mat4 view);
+
+    /**
+     *
      * @param ecs The registry containing all the entities from which to grab the rendearbles from
      * @param shaderType The type of shader that is used for rendering this model
      * @param renderEngine The specified render engine to use for rendering this model

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -47,6 +47,7 @@ void Scene::init()
 
 void Scene::update()
 {
+    bbSystems.setLight(*renderEngine, ShaderType::Default, viewMatrix);
     Systems::drawModels(bbECS, ShaderType::Default, *renderEngine, resources.getSceneModels(), projectionMatrix, viewMatrix);
 }
 


### PR DESCRIPTION
## What problem does this pull request address?
<!-- Give a summary of the problem being fixed or the enhancement being implemented. Tag the issue or task wherever possible. -->

This is a stepping stone to implementing directional lighting in issue #100 . This decouples light uniforms from the model drawing function in Scene Systems

## How does this pull request solve the problem?
<!-- Give a summary of the solution being implemented and any details that will help the reviewer understand the changes. Explain why you chose this approach and any relevant design decisions you made. Are there any consequences beyond the scope of the problem being addressed? -->

The setting of light uniforms from shaders which have lighting uniforms has been delegated to a different function. This function will set the uniforms from shaders which have support for lighting. This is a better implementation as we now can draw models with or without lighting if need be, we just need to specify a shader that doesn't have lights when we want to draw models without lighting. This implies that in the future there may need to be a check for which shader is currently attached for lighting as to avoid trying to set uniforms from shaders which don't have any lighting support.

Directional lighting is currently not implemented but this decoupling will make the implementation of directional lighting a lot easier as lighting is now more modular.

## What testing has been performed?
<!-- Use checkboxes to list tests from your test plan and check them off as they are completed. -->
<!-- If applicable, explain which tests will be done after the pull request is merged. -->
<!-- If no testing is done or applicable, please describe your rationale behind it. -->

- [x] Builds successfully
- [x] Runs successfully
- [x] Previous functional implementation of lighting is undisturbed and bears the same results after decoupling
