### PR TITLE
Fixed Duplicate .Obj Entries in Model Resource Map

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -6,7 +6,10 @@
 
 void Systems::generateModelFromComponent(const ModelComponent & modelComp, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels)
 {
-    sceneModels.emplace(std::pair<std::string, std::unique_ptr<Model>>(modelComp.model_path, GraphicsFactory<GraphicsAPI::OpenGL>::CreateModel(modelComp.model_path, modelComp.material_path)));
+    if(sceneModels.find(modelComp.model_path) == sceneModels.end())
+    {
+        sceneModels.emplace(std::pair<std::string, std::unique_ptr<Model>>(modelComp.model_path, GraphicsFactory<GraphicsAPI::OpenGL>::CreateModel(modelComp.model_path, modelComp.material_path)));
+    }
 }
 
 void Systems::createModelComponents(ECS &ecs, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels)


### PR DESCRIPTION
## What problem does this pull request address?
<!-- Give a summary of the problem being fixed or the enhancement being implemented. Tag the issue or task wherever possible. -->

This solves the problem where multiple instances of the same model would be loaded. Essentially resources would have a bunch of entries pointing to the same model data, which is not very rescource-efficient and drastically increased scene load time.

## How does this pull request solve the problem?
<!-- Give a summary of the solution being implemented and any details that will help the reviewer understand the changes. Explain why you chose this approach and any relevant design decisions you made. Are there any consequences beyond the scope of the problem being addressed? -->

A check was added in the System model-generation-from-component function which checks whether the entry actually exists inside of the resource map for models. If the entry doesn't exist in the map then it emplaces the obj entry into it. This ensures that there is only one of each .obj model entry in the model resource, significantly reducing resource requirements and load times.

No further changes were needed to any other model-related components as all transforms and object manipulations are handled in the frontend, and don't actually modify the resource data for models, only reference it.

## What testing has been performed?
<!-- Use checkboxes to list tests from your test plan and check them off as they are completed. -->
<!-- If applicable, explain which tests will be done after the pull request is merged. -->
<!-- If no testing is done or applicable, please describe your rationale behind it. -->

- [x] Builds successfully
- [x] Runs successfully
- [x] Ran Scene multiple times and saw significantly faster load time for scene
- [x] Checked model resouce map entries and there are far less .obj model entries without any model loss in the scene
- [x] Viewport shows that all objects are still rendering into the scene with the right transforms and shaders
