### PR TITLE
#116 register c++ to lua

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/CMakeLists.txt
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/CMakeLists.txt
@@ -11,4 +11,5 @@ set(SOURCES
 
 target_sources(BBAI PRIVATE ${SOURCES})
 
-target_link_libraries(BBAI PRIVATE BBScript)
+target_link_libraries(BBAI PRIVATE BBComponentSystem)
+target_link_libraries(BBAI PUBLIC glm sol2)

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
@@ -42,11 +42,7 @@ void FSM::update()
 
 void FSM::changeState(const std::string& newState) 
 {  
-  std::cout << "Current State: " << m_currentState << std::endl;
-  if (m_npcReference) std::cout << "playerbound" << std::endl;
-  else std::cout << "player not bound" << std::endl;
-
-  if (m_luaState[newState].valid()) {
+  if (!m_luaState[m_currentState].valid()) {
     std::string errMsg =
         "AI state: " + newState + " not found on change state method";
     throw std::runtime_error(errMsg);
@@ -56,8 +52,6 @@ void FSM::changeState(const std::string& newState)
   m_luaState[m_currentState]["onExit"](*m_npcReference);  // execute exit code
   m_currentState = newState;                             // change states
   m_luaState[m_currentState]["onEnter"](*m_npcReference);  // execute enter code of new state
-
-  std::cout << "New Current State: " << m_currentState << std::endl;
 }
 
 void FSM::setStatePath(const std::filesystem::path& path)

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
@@ -42,16 +42,16 @@ void FSM::update()
 
 void FSM::changeState(const std::string& newState) 
 {  
-  if (!m_luaState[newState].valid()) {
+    if (!m_luaState[newState].valid()) {
     std::string errMsg =
         "AI state: " + newState + " not found on change state method";
     throw std::runtime_error(errMsg);
-  }
+    }
 
-  m_previousState = m_currentState;                      // track previous state
-  m_luaState[m_currentState]["onExit"](*m_npcReference);  // execute exit code
-  m_currentState = newState;                             // change states
-  m_luaState[m_currentState]["onEnter"](*m_npcReference);  // execute enter code of new state
+    m_previousState = m_currentState;                      // track previous state
+    m_luaState[m_currentState]["onExit"](*m_npcReference);  // execute exit code
+    m_currentState = newState;                             // change states
+    m_luaState[m_currentState]["onEnter"](*m_npcReference);  // execute enter code of new state
 }
 
 void FSM::setStatePath(const std::filesystem::path& path)

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
@@ -42,7 +42,7 @@ void FSM::update()
 
 void FSM::changeState(const std::string& newState) 
 {  
-  if (!m_luaState[m_currentState].valid()) {
+  if (!m_luaState[newState].valid()) {
     std::string errMsg =
         "AI state: " + newState + " not found on change state method";
     throw std::runtime_error(errMsg);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.h
@@ -6,8 +6,7 @@
 
 #include <string>
 #include <filesystem>
-
-#include "BBScript.h"
+#include <sol/sol.hpp>
 
 class NPC;
 
@@ -24,12 +23,6 @@ public:
     /// @brief normal update call for state machine
     /// runs current state update, and global state update
     void update();
-
-    /// @author Alan
-    /// @brief changes states, updates previous state, runs onExit and onEnter
-    /// accordingly
-    /// @param newState the new state to transition to
-    void changeStateAI(const std::string& newState);
 
     /// @author Alan
     /// @brief changes states, updates previous state, runs onExit and onEnter

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.h
@@ -17,20 +17,32 @@ class NPC;
 class FSM
 {
 public:
-    FSM(NPC* FSMOwner, const std::filesystem::path& statesPath, const std::string& initialState);
+    FSM(NPC* FSMOwner, const std::filesystem::path& statesPath,
+        const std::string& initialState, sol::state& lua_state);
 
     /// @author Alan
     /// @brief normal update call for state machine
     /// runs current state update, and global state update
-    /// @param lua_state the script to read from
-    void update(sol::state & lua_state);
+    void update();
+
+    /// @author Alan
+    /// @brief changes states, updates previous state, runs onExit and onEnter
+    /// accordingly
+    /// @param newState the new state to transition to
+    void changeStateAI(const std::string& newState);
+
+    /// @author Alan
+    /// @brief changes states, updates previous state, runs onExit and onEnter
+    /// accordingly
+    /// @param newState the new state to transition to
+    void changeState(const std::string& newState);
 
     /// @author Alan
     /// @brief evaluate if path extension is correct and then sets the member statePath its value
     /// @param path the string to get the ai script
-    void SetStatePath(const std::filesystem::path& path);
+    void setStatePath(const std::filesystem::path& path);
 
-    std::filesystem::path& GetStatePath();
+    std::filesystem::path& getStatePath();
 
 private:
     NPC* m_npcReference; // reference to the NPC that owns this FSM
@@ -40,4 +52,6 @@ private:
     std::string m_previousState;
     std::string m_globalState;
     std::string m_currentState;
+
+    sol::state& m_luaState;
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
@@ -4,17 +4,19 @@
 
 #include "NPC.h"
 
-NPC::NPC(const std::filesystem::path& statesPath, const std::string& initialState) : m_FSM(this, statesPath, initialState) 
-{
+NPC::NPC(const std::filesystem::path& statesPath,
+         const std::string& initialState, sol::state& lua_state)
+    : m_FSM(this, statesPath, initialState, lua_state) {
 
 }
 
-void NPC::Update(sol::state & lua_state)
+/*
+void NPC::update()
 {
-	m_FSM.update(lua_state);
+	m_FSM.update();
 }
-
-FSM& NPC::GetFSM() 
+*/
+FSM& NPC::getFSM() 
 { 
 	return m_FSM; 
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
@@ -10,12 +10,12 @@ NPC::NPC(const std::filesystem::path& statesPath,
 
 }
 
-/*
-void NPC::update()
+void NPC::update(const float deltaTime)
 {
+    m_DeltaTimeAI = deltaTime;
 	m_FSM.update();
 }
-*/
+
 FSM& NPC::getFSM() 
 { 
 	return m_FSM; 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "BBScript.h"
 #include "FSM.h"
 
 /// @author Alan
@@ -14,15 +13,17 @@ class NPC
 {
 public:
     NPC(const std::filesystem::path& statesPath, const std::string& initialState, sol::state& lua_state);
-
-    /*
+    
     /// @author Alan
     /// @brief update call for FSM
     /// @param lua_state ai script to read from
-    void update(sol::state& lua_state);
-    */
+    void update(const float deltaTime);
+
     FSM& getFSM();
 
 private:
     FSM m_FSM;
+
+    float m_DeltaTimeAI; // time elasped for AI update call
+
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -13,14 +13,15 @@
 class NPC 
 {
 public:
-    NPC(const std::filesystem::path& statesPath, const std::string& initialState);
+    NPC(const std::filesystem::path& statesPath, const std::string& initialState, sol::state& lua_state);
 
+    /*
     /// @author Alan
     /// @brief update call for FSM
     /// @param lua_state ai script to read from
-    void Update(sol::state& lua_state);
-
-    FSM& GetFSM();
+    void update(sol::state& lua_state);
+    */
+    FSM& getFSM();
 
 private:
     FSM m_FSM;

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Components.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Components.h
@@ -67,7 +67,7 @@ struct AIControllerComponent
 {
     NPC npc;
 
-    AIControllerComponent(const std::filesystem::path& statesPath, const std::string& initialState)
-        : npc(NPC(statesPath, initialState))
+    AIControllerComponent(const std::filesystem::path& statesPath, const std::string& initialState, sol::state& lua_state)
+        : npc(NPC(statesPath, initialState, lua_state))
     {}
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.cpp
@@ -19,7 +19,7 @@ Entity EntityFactory::create_from_file(ECS & ecs, sol::state & lua_state, const 
     if(entityTable.valid())
     {
         namedEntity = ecs.CreateEntity();
-        load_components(ecs, namedEntity, entityTable);
+        load_components(ecs, namedEntity, lua_state, entityTable);
 
         return namedEntity;
     }
@@ -40,14 +40,14 @@ Entity EntityFactory::create_from_file(ECS & ecs, sol::state & lua_state, const 
     if(entityTable.valid())
     {
         namedEntity = ecs.CreateEntity();
-        load_components(ecs, namedEntity, entityTable, xPos, yPos, zPos);
+        load_components(ecs, namedEntity, lua_state, entityTable, xPos, yPos, zPos);
 
         return namedEntity;
     }
     return namedEntity;
 }
 
-void EntityFactory::load_components(ECS& ecs, Entity& entity, const sol::table& table)
+void EntityFactory::load_components(ECS& ecs, Entity& entity, sol::state& lua_state, const sol::table& table)
 {
     if(table["Transform"].valid())
     {
@@ -59,11 +59,11 @@ void EntityFactory::load_components(ECS& ecs, Entity& entity, const sol::table& 
     }
     if(table["AI"].valid())
     {
-        loadAIController(ecs, entity, table["AI"]);
+        loadAIController(ecs, entity, lua_state, table["AI"]);
     }
 }
 
-void EntityFactory::load_components(ECS& ecs, Entity& entity, const sol::table& table, float xPos, float yPos, float zPos)
+void EntityFactory::load_components(ECS& ecs, Entity& entity, sol::state& lua_state, const sol::table& table, float xPos, float yPos, float zPos)
 {
     if(table["Transform"].valid())
     {
@@ -75,7 +75,7 @@ void EntityFactory::load_components(ECS& ecs, Entity& entity, const sol::table& 
     }
     if(table["AI"].valid())
     {
-        loadAIController(ecs, entity, table["AI"]);
+        loadAIController(ecs, entity, lua_state, table["AI"]);
     }
 }
 
@@ -135,12 +135,12 @@ void EntityFactory::loadModel(ECS &ecs, Entity &entity, const sol::table &model)
     modelComponent.material_path = material_location;
 }
 
-void EntityFactory::loadAIController(ECS& ecs, Entity& entity, const sol::table& ai)
+void EntityFactory::loadAIController(ECS& ecs, Entity& entity, sol::state& lua_state, const sol::table& ai)
 {
     std::string statesPath = ai["StatesPath"];
     std::string initialState = ai["InitialState"];
 
-    AIControllerComponent& aicComponent = entity.AddComponent<AIControllerComponent>(ecs.getReg(), statesPath, initialState); // add an AI controller to entity
+    AIControllerComponent& aicComponent = entity.AddComponent<AIControllerComponent>(ecs.getReg(), statesPath, initialState, lua_state); // add an AI controller to entity
 
     std::cout << "Loaded AI component" << std::endl; //@Debug Line, to be removed
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.h
@@ -36,19 +36,21 @@ private:
      *
      * @param ecs The ecs to load components from
      * @param entity entity to add components to
+     * @param lua_state lua state
      * @param table tables
      */
-    void load_components(ECS &ecs, Entity &entity, const sol::table &table);
+    void load_components(ECS &ecs, Entity &entity, sol::state& lua_state, const sol::table &table);
 
     /**
      * @param ecs  The ecs to load components from
      * @param entity the entity to attach components to
+     * @param lua_state lua state
      * @param table the sol table to compare
      * @param xPos x translate
      * @param yPos y translate
      * @param zPos z translate
      */
-    void load_components(ECS &ecs, Entity &entity, const sol::table &table, float xPos, float yPos, float zPos);
+    void load_components(ECS &ecs, Entity &entity, sol::state& lua_state, const sol::table &table, float xPos, float yPos, float zPos);
 
     /**
      *
@@ -79,8 +81,9 @@ private:
     /**
      *
      * @param ecs the ecs registry to load model component from
+     * @param lua_state lua state
      * @param entity the entity to attach to
      * @param ai the ai table to compare against
      */
-    void loadAIController(ECS &ecs, Entity &entity, const sol::table &ai);
+    void loadAIController(ECS &ecs, Entity &entity, sol::state& lua_state, const sol::table &ai);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -104,13 +104,14 @@ void Systems::updateTransformComponent(ECS &ecs, const std::string& tag, glm::ve
 
 }
 
-void Systems::updateAI(ECS &ecs) 
+void Systems::updateAI(ECS &ecs, const float deltaTime) 
 {
     auto group = ecs.GetAllEntitiesWith<AIControllerComponent>();
 
     for (auto entity : group)
     {
       auto& aic = group.get<AIControllerComponent>(entity);
-      aic.npc.getFSM().update();
+
+      aic.npc.update(deltaTime);
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -4,6 +4,7 @@
 
 #include "Systems.h"
 #include "BBScript.h"
+#include "RegisterAIScripts.h"
 
 void Systems::generateModelFromComponent(const ModelComponent & modelComp, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels)
 {
@@ -33,9 +34,11 @@ void Systems::ReadAIScripts(ECS& ecs, sol::state & lua_state)
     {
         auto& aic = group.get<AIControllerComponent>(entity);
 
-        if(aic.npc.GetFSM().GetStatePath().extension() != ".lua") { throw std::runtime_error("Lua file is no lua file"); }
-        lua_state.script_file(aic.npc.GetFSM().GetStatePath().string());
+        if(aic.npc.getFSM().getStatePath().extension() != ".lua") { throw std::runtime_error("Lua file is no lua file"); }
+        lua_state.script_file(aic.npc.getFSM().getStatePath().string());
     }
+    registerScriptedFSM(lua_state);
+    registerScriptedNPC(lua_state);
 }
 
 void Systems::setLight(RenderEngine & renderEngine, const ShaderType & shaderType, glm::mat4 view)
@@ -101,13 +104,13 @@ void Systems::updateTransformComponent(ECS &ecs, const std::string& tag, glm::ve
 
 }
 
-void Systems::updateAI(ECS &ecs, sol::state & lua_state) 
+void Systems::updateAI(ECS &ecs) 
 {
     auto group = ecs.GetAllEntitiesWith<AIControllerComponent>();
 
     for (auto entity : group)
     {
       auto& aic = group.get<AIControllerComponent>(entity);
-      aic.npc.Update(lua_state);
+      aic.npc.getFSM().update();
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -71,5 +71,5 @@ public:
      * @brief update AI call
      * @param sceneNPCs vector of all npcs to iterate through
      */
-    static void updateAI(ECS &ecs);
+    static void updateAI(ECS &ecs, const float deltaTime);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -70,7 +70,6 @@ public:
      * @author Alan
      * @brief update AI call
      * @param sceneNPCs vector of all npcs to iterate through
-     * @param lua_state AI script to read for FSM in NPCs
      */
-    static void updateAI(ECS &ecs, sol::state & lua_state);
+    static void updateAI(ECS &ecs);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -47,7 +47,7 @@ void Scene::init()
     bbSystems.ReadAIScripts(bbECS, lua.getLuaState());
 }
 
-void Scene::update(float deltaTime)
+void Scene::update(const float deltaTime)
 {
     accumulatedFrameTime += deltaTime;
     
@@ -57,7 +57,7 @@ void Scene::update(float deltaTime)
     while (accumulatedFrameTime >= UpdateAIInterval) 
     {
         std::cout << "update all AI call" << std::endl;
-        Systems::updateAI(bbECS);
+        Systems::updateAI(bbECS, deltaTime);
         accumulatedFrameTime -= UpdateAIInterval;
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -57,7 +57,7 @@ void Scene::update(float deltaTime)
     while (accumulatedFrameTime >= UpdateAIInterval) 
     {
         std::cout << "update all AI call" << std::endl;
-        Systems::updateAI(bbECS, lua.getLuaState());
+        Systems::updateAI(bbECS);
         accumulatedFrameTime -= UpdateAIInterval;
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.h
@@ -74,7 +74,7 @@ public:
     /**
      *
      */
-    void update(float deltaTime);
+    void update(const float deltaTime);
 private:
     glm::mat4 projectionMatrix; ///The camera projection matrix (temporary hack until everything from EntryPoint is ported here).
     glm::mat4 viewMatrix; ///The camera projection matrix (temporary hack until everything from EntryPoint is ported here).

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/CMakeLists.txt
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 add_library(BBScript STATIC)
 
-target_sources(BBScript PRIVATE BBScript.cpp BBScript.h)
-target_link_libraries(BBScript sol2 LUA)
+target_sources(BBScript PRIVATE BBScript.cpp BBScript.h RegisterAIScripts.h RegisterAIScripts.cpp)
+target_link_libraries(BBScript sol2 LUA BBAI)
 target_include_directories(BBScript PRIVATE ${PROJECT_SOURCE_DIR}/Vendors/Lua/lua-5.4.6/)

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Alan 27/05/2024
+//
+
+#include "RegisterAIScripts.h"
+#include "FSM.h"
+#include "NPC.h"
+
+void registerScriptedFSM(sol::state& lua_state) {
+  lua_state.new_usertype<FSM>("FSM", 
+      "changeState", &FSM::changeState
+  );
+}

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -6,8 +6,17 @@
 #include "FSM.h"
 #include "NPC.h"
 
+
 void registerScriptedFSM(sol::state& lua_state) {
-  lua_state.new_usertype<FSM>("FSM", 
-      "changeState", &FSM::changeState
-  );
+    lua_state.new_usertype<FSM>("FSM", 
+        sol::constructors<FSM(NPC*, const std::filesystem::path&, const std::string&, sol::state&)>(),
+        "changeState", &FSM::changeState
+    );
+}
+
+void registerScriptedNPC(sol::state& lua_state) {
+    lua_state.new_usertype<NPC>("NPC", 
+        sol::constructors<NPC(const std::filesystem::path&, const std::string&, sol::state&)>(),
+        "getFSM", &NPC::getFSM
+    );
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.h
@@ -1,0 +1,9 @@
+//
+// Created by Alan 27/05/2024
+//
+
+#pragma once
+
+#include "BBScript.h"
+
+void registerScriptedFSM(sol::state& lua_state);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.h
@@ -7,3 +7,4 @@
 #include "BBScript.h"
 
 void registerScriptedFSM(sol::state& lua_state);
+void registerScriptedNPC(sol::state& lua_state);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AI/States.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AI/States.lua
@@ -4,9 +4,17 @@
 
 -------------------------------------------------------------------------------
 Global = {
-	Update = function(NPC)
-		print("in global state")
+	onEnter = function(NPC)
+		print("Entered Global state");
+	end,
 
+	Update = function(NPC)
+		print("in global state");
+
+	end,
+
+	onExit = function(NPC)
+		print("Exiting Global state");
 	end
 }
 
@@ -16,10 +24,18 @@ Global = {
 
 -------------------------------------------------------------------------------
 Idle = {
-	Update = function(NPC)
-		print("in idle state")
-		NPC:changeState("Patrol")
+	onEnter = function(NPC)
+		print("Entered Idle state");
+	end,
 
+	Update = function(NPC)
+		print("in idle state");
+		NPC:getFSM():changeState("Patrol");
+
+	end,
+
+	onExit = function(NPC)
+		print("Exiting Idle state");
 	end
 }
 
@@ -29,8 +45,16 @@ Idle = {
 
 -------------------------------------------------------------------------------
 Patrol = {
-	Update = function(NPC)
-		print ("in patrol state")
+	onEnter = function(NPC)
+		print("Entered Patrol state");
+	end,
 
+	Update = function(NPC)
+		print ("in patrol state");
+
+	end,
+
+	onExit = function(NPC)
+		print("Exiting Patrol state");
 	end
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AI/States.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AI/States.lua
@@ -4,7 +4,7 @@
 
 -------------------------------------------------------------------------------
 Global = {
-	Update = function(player)
+	Update = function(NPC)
 		print("in global state")
 
 	end
@@ -16,8 +16,9 @@ Global = {
 
 -------------------------------------------------------------------------------
 Idle = {
-	Update = function(player)
+	Update = function(NPC)
 		print("in idle state")
+		NPC:changeState("Patrol")
 
 	end
 }
@@ -28,7 +29,7 @@ Idle = {
 
 -------------------------------------------------------------------------------
 Patrol = {
-	Update = function(player)
+	Update = function(NPC)
 		print ("in patrol state")
 
 	end

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/Cube.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/Cube.lua
@@ -19,9 +19,5 @@ Entity = {
     Model = {
         ModelPath = "Resources/Models/Rock_THE.obj",
         MaterialPath = "Resources/heightmaps/Grass.png"
-    },
-    AI = {
-        StatesPath = "Game/AI/States.lua",
-        InitialState = "Idle"
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPC.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPC.lua
@@ -1,0 +1,27 @@
+Entity = {
+    Transform = {
+        Position = {
+            x = 0,
+            y = 0,
+            z = 0
+        },
+        Rotation = {
+            x = 0,
+            y = 0,
+            z = 0
+        },
+        Scale = {
+            x = 10,
+            y = 10,
+            z = 10
+        }
+    },
+    Model = {
+        ModelPath = "Resources/Models/D20.obj",
+        MaterialPath = "Resources/Models/Disabled_Pokemon_Go_-_Eevee___Zubat_0-3_screenshot.png"
+    },
+    AI = {
+        StatesPath = "Game/AI/States.lua",
+        InitialState = "Idle"
+    }
+}

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/exitCube.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/exitCube.lua
@@ -19,9 +19,5 @@ Entity = {
     Model = {
         ModelPath = "Resources/Models/Splashcreen.obj",
         MaterialPath = "Resources/Models/splashscreen.png"
-    },
-    AI = {
-        StatesPath = "Game/AI/States.lua",
-        InitialState = "Patrol"
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/master_file.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/master_file.lua
@@ -1,6 +1,8 @@
 --Load all game entities from scripts here!
 
 create_entity("Game/Cube.lua");
+create_entityTR("Game/NPC.lua", 500, 10, 450);
+create_entityTR("Game/NPC.lua", 400, 10, 450);
 
 for start=0, 4000, 1000 do
     for start1=0, 4000, 1000 do
@@ -21,4 +23,4 @@ end
 --end
 
 create_entity("Game/exitCube.lua");
-create_entity("Game/ico-sphere.lua");
+--create_entity("Game/ico-sphere.lua");


### PR DESCRIPTION
## What problem does this pull request address?
We need a way to register c++ functions to lua. Specifically for NPC functions to be called from Lua

## How does this pull request solve the problem?
Provides a file - RegisterAIScripts.cpp - to call that registers NPC and FSM functions to Lua. The tests are done with `changeState()` in the FSM class.
2 D20.obj entities are created to showcase this.

Note that an entity lua file currently has an Initial State bound to it i.e., NPC.lua
But future improvements can be to create another method in Entity Factory to be able to edit this in the master_file.lua file
![image](https://github.com/Minywire/Bottlebrush_Engine/assets/87167180/f9f8fb27-173e-46e1-a238-e09cf4cfc496)
![image](https://github.com/Minywire/Bottlebrush_Engine/assets/87167180/76836d4b-4e3d-4d39-8bc3-5f137045dece)

I also removed AI components from other entity objects, Cube.lua and exitCube.lua and made 1 NPC.lua file to replace them.

Closes #116 
Addresses #115 & #89 

## What testing has been performed?

![image](https://github.com/Minywire/Bottlebrush_Engine/assets/87167180/1a2d8705-da1d-46f7-bbd8-e492a8b5f4c6)

- [x] Lua calls `changeState()` through the NPC class
- [x] Print calls are done on transition
- [x] Builds successfully
- [x] Runs successfully
