### PR TITLE
#130 set npc to terrain height

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -203,11 +203,11 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
         {
             auto& terrainComp = terrainGroup.get<TerrainComponent>(terrainEnitity);
             auto& terrain = sceneTerrain.at(terrainComp.terrain_path);
-            float newY = terrain.GetHeight(transform.position.x, transform.position.z);
 
             // as getHeight returns 0 if its out of bounds. Avoids collision
             // with other terrains, if there were more than 1.
-            if (newY == 0) continue; 
+            if (!terrain.GetHeight(transform.position.x, transform.position.z).has_value()) continue;
+            float newY = terrain.GetHeight(transform.position.x, transform.position.z).value();
 
             // set the new y position
             transform.position.y = newY + 10; // plus an offset, should be taken out once other physics is implemented

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -160,7 +160,7 @@ void Systems::updateTransformComponent(ECS &ecs, const std::string& tag, glm::ve
 
 }
 
-void Systems::updateAIMovements(ECS& ecs, float deltaTime)
+void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<std::string, Terrain> & sceneTerrain)
 {
     auto group = ecs.GetAllEntitiesWith<TransformComponent, AIControllerComponent>();
 
@@ -189,6 +189,22 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime)
         transform.position.z += npc.GetDirection().y * deltaTime * npc.GetCurrentSpeed();
         // rotate the character to face the direction, currently given in radians
         transform.rotation.y = std::atan2(npc.GetDirection().y, npc.GetDirection().x);
+
+        //change the NPC's y position to the terrain height
+        auto terrainGroup = ecs.GetAllEntitiesWith<TerrainComponent>();
+        for (auto terrainEnitity : terrainGroup)
+        {
+            auto& terrainComp = terrainGroup.get<TerrainComponent>(terrainEnitity);
+            auto& terrain = sceneTerrain.at(terrainComp.terrain_path);
+            float newY = terrain.GetHeight(transform.position.x, transform.position.z);
+
+            // as getHeight returns 0 if its out of bounds. Avoids collision
+            // with other terrains, if there were more than 1.
+            if (newY == 0) continue; 
+
+            // set the new y position
+            transform.position.y = newY + 10; // plus an offset, should be taken out once other physics is implemented
+        }
     }
 }
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -206,8 +206,9 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
 
             // as getHeight returns 0 if its out of bounds. Avoids collision
             // with other terrains, if there were more than 1.
-            if (!terrain.GetHeight(transform.position.x, transform.position.z).has_value()) continue;
-            float newY = terrain.GetHeight(transform.position.x, transform.position.z).value();
+            auto heightOpt = terrain.GetHeight(transform.position.x, transform.position.z);
+            if (!heightOpt.has_value()) continue;
+            float newY = heightOpt.value();
 
             // set the new y position
             transform.position.y = newY + 10; // plus an offset, should be taken out once other physics is implemented

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -204,8 +204,8 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
             auto& terrainComp = terrainGroup.get<TerrainComponent>(terrainEnitity);
             auto& terrain = sceneTerrain.at(terrainComp.terrain_path);
 
-            // as getHeight returns 0 if its out of bounds. Avoids collision
-            // with other terrains, if there were more than 1.
+            // Optional returns if its out of bounds. 
+            // Avoids collision with other terrains, if there were more than 1.
             auto heightOpt = terrain.GetHeight(transform.position.x, transform.position.z);
             if (!heightOpt.has_value()) continue;
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -208,10 +208,9 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
             // with other terrains, if there were more than 1.
             auto heightOpt = terrain.GetHeight(transform.position.x, transform.position.z);
             if (!heightOpt.has_value()) continue;
-            float newY = heightOpt.value();
 
             // set the new y position
-            transform.position.y = newY + 10; // plus an offset, should be taken out once other physics is implemented
+            transform.position.y = heightOpt.value() + 10; // plus an offset, should be taken out once other physics is implemented
         }
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -102,8 +102,10 @@ public:
      * @author Alan
      * @param ecs The registry for which to update components to
      * @param deltaTime to translate in accordance to FPS
+     * @param sceneTerrain a map containing all terrains
      */
-    static void updateAIMovements(ECS &ecs, float deltaTime);
+    static void updateAIMovements(ECS &ecs, float deltaTime, 
+        std::unordered_map<std::string, Terrain> & sceneTerrain);
 
     /**
      * @author Alan

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -220,7 +220,7 @@ void Scene::update()
         Systems::drawModels(bbECS, ShaderType::Default, *renderEngine,
                             resources.getSceneModels(), projectionMatrix,
                             viewMatrix);
-        Systems::updateAIMovements(bbECS, deltaTime);
+        Systems::updateAIMovements(bbECS, deltaTime, resources.getSceneTerrain());
         while (accumulatedFrameTime >= UpdateAIInterval) {
             std::cout << "update all AI call" << std::endl;
             Systems::updateAI(bbECS, lua.getLuaState(), accumulatedFrameTime);


### PR DESCRIPTION
## What problem does this pull request address?
NPCs Y position is not being set by anything currently. It needs to be set by Terrain's height values

closes #130
addresses #89 

## How does this pull request solve the problem?
Adds terrain getter from ecs to the `UpdateAIMovement` func in systems. Then checks if the `Terrain::GetHeight` returns 0 it ignores is, as this value represents it as "being out of bounds of the grid" to cater for multiple instances of Terrains as that is the current design.

## What testing has been performed?
- [x] Adjust NPC's height to terrain per tick

https://github.com/Minywire/Bottlebrush_Engine/assets/87167180/fc20a130-7f40-42fc-8ebb-313ef391c630


- [x] Builds successfully
- [x] Runs successfully
