### PR TITLE
Added Camera terrain collision and camera restriction flag in scene

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -275,9 +275,9 @@ void Systems::updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map
 
     for (auto entity : group)
     {
-        auto& currentTerrainComp = group.get<TerrainComponent>(entity);
-        auto& terrainTransform = group.get<TransformComponent>(entity);
-        auto& currentTerrain = terrains.at(currentTerrainComp.terrain_path);
+        const auto& currentTerrainComp = group.get<TerrainComponent>(entity);
+        const auto& terrainTransform = group.get<TransformComponent>(entity);
+        const auto& currentTerrain = terrains.at(currentTerrainComp.terrain_path);
 
         glm::mat4 model = {1};
         model = glm::translate(model, terrainTransform.position);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -279,26 +279,12 @@ void Systems::updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map
         const auto& terrainTransform = group.get<TransformComponent>(entity);
         const auto& currentTerrain = terrains.at(currentTerrainComp.terrain_path);
 
-        glm::mat4 model = {1};
-        model = glm::translate(model, terrainTransform.position);
-        model = glm::rotate(model, glm::radians(terrainTransform.rotation.x), glm::vec3(1,0,0));
-        model = glm::rotate(model, glm::radians(terrainTransform.rotation.y), glm::vec3(0,1,0));
-        model = glm::rotate(model, glm::radians(terrainTransform.rotation.z), glm::vec3(0,0,1));
-        model = glm::scale(model, terrainTransform.scale);
-
-        const glm::vec3 local_position =
-            glm::inverse(model) * glm::vec4(camera.GetPosition(), 1);
-
         const std::optional<float> terrain_height =
-            currentTerrain.GetHeight(local_position.x, local_position.z);
+            currentTerrain.GetHeight(camera.GetPosition().x, camera.GetPosition().z);
 
         if (terrain_height.has_value())
         {
             camera.SetPositionY(terrain_height.value() + offset_y);
         } 
-        else
-        {
-            camera.SetPositionY(0);
-        }
     }
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -209,22 +209,6 @@ void Systems::drawTerrain(const ECS& ecs, const ShaderType& terrainShader, Rende
     }
 }
 
-void Systems::updateTransformComponent(ECS &ecs, const std::string& tag, glm::vec3 trans, glm::vec3 rot)
-{
-    auto group = ecs.GetAllEntitiesWith<TransformComponent, TagComponent>();
-
-    for(auto entity : group)
-    {
-        auto& currentEntityComponent =  group.get<TransformComponent>(entity);
-        if(group.get<TagComponent>(entity).tag == tag)
-        {
-//            currentEntityComponent.position = trans; //can't do this since the component passed in is a const reference so im currently trying to find a proper way to do it.
-//            currentEntityComponent.rotation = rot;
-        }
-    }
-
-}
-
 void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<std::string, Terrain> & sceneTerrain)
 {
     auto group = ecs.GetAllEntitiesWith<TransformComponent, AIControllerComponent>();
@@ -285,7 +269,7 @@ void Systems::updateAI(ECS& ecs, sol::state& lua_state, float deltaTime) {
     }
 }
 
-void Systems::updateCameraTerrainHeight(ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera,  float offset_y)
+void Systems::updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera,  float offset_y)
 {
     auto group = ecs.GetAllEntitiesWith<TerrainComponent, TransformComponent>();
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -152,4 +152,6 @@ public:
      * @param AIUpdateIntervalTime this is the time representing the time for the ai to be called
      */
     static void updateAI(ECS &ecs, sol::state &lua_state, float deltaTime);
+
+    static void updateCameraTerrainHeight(ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera, float offset_y);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -144,5 +144,5 @@ public:
      */
     static void updateAI(ECS &ecs, sol::state &lua_state, float deltaTime);
 
-    static void updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera, float offset_y);
+    static void updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera, float offset_y = 10.0f);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -127,15 +127,6 @@ public:
     static void drawTerrain(const ECS& ecs, const ShaderType& terrainShader, RenderEngine& renderEngine, std::unordered_map<std::string, Terrain> & sceneTerrain, bool grayscale, glm::mat4 projection, glm::mat4 view);
 
     /**
-     *
-     * @param ecs The registry for which to update the transform components to
-     * @param tag The tag component used for entity comparison
-     * @param trans The translate to be applied
-     * @param rot The rotation to be applied
-     */
-    void updateTransformComponent(ECS &ecs, const std::string& tag, glm::vec3 trans, glm::vec3 rot);
-
-    /**
      * @author Alan
      * @param ecs The registry for which to update components to
      * @param deltaTime to translate in accordance to FPS
@@ -153,5 +144,5 @@ public:
      */
     static void updateAI(ECS &ecs, sol::state &lua_state, float deltaTime);
 
-    static void updateCameraTerrainHeight(ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera, float offset_y);
+    static void updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera, float offset_y);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBInput/Window.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBInput/Window.cpp
@@ -32,6 +32,7 @@ Window::Window(WindowMode window_mode, CursorMode cursor_mode,
   glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE);
   glfwWindowHint(GLFW_DOUBLEBUFFER, GLFW_TRUE);
   glfwWindowHint(GLFW_SAMPLES, kMultiSamples);
+  glfwWindowHint(GLFW_DEPTH_BITS, 32);
 }
 
 void Window::Create() {

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -159,8 +159,6 @@ void Scene::init()
     glfwSetKeyCallback(window.GetContext(), KeyCallback);
     glfwSetCursorPosCallback(window.GetContext(), MouseCallback);
     glfwSetScrollCallback(window.GetContext(), ScrollCallback);
-    glfwWindowHint(GLFW_DEPTH_BITS, 32);  // Request a 32-bit depth buffer
-
    
     if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
       std::cerr << "ERROR: Failed to initialize GLAD!" << std::endl;
@@ -168,8 +166,6 @@ void Scene::init()
     }
 
     glEnable(GL_DEPTH_TEST);
-    glEnable(GL_POLYGON_OFFSET_FILL);
-    glPolygonOffset(1.0, 1.0);
     
     mainCamera.SetPosition(1000.0f, 100.0f, 1000.0f);
     mainCamera.SetSensitivity(0.05f);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -169,7 +169,7 @@ void Scene::init()
     
     mainCamera.SetPosition(1000.0f, 100.0f, 1000.0f);
     mainCamera.SetSensitivity(0.05f);
-    mainCamera.SetSpeed(100.0f);
+    mainCamera.SetSpeed(1000.0f);
     mainCamera.SetZoom(30.0f);
 
     bbSystems.RegisterAIFunctions(bbECS, lua.getLuaState(), mainCamera); // register functions before running scripts

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -19,6 +19,8 @@ void KeyCallback(Window::WindowContext window, int key, int scancode, int action
 
     if (key == GLFW_KEY_C && action == GLFW_PRESS) scene->setWireFrameFlag(!scene->getWireframeFlag());
 
+    if (key == GLFW_KEY_R && action == GLFW_PRESS) scene->setCameraRestriction(!scene->getCameraRestriction());
+
     if (action == GLFW_PRESS && key == GLFW_KEY_LEFT_SHIFT)
       scene->getCamera().SetSpeed(scene->getCamera().GetSpeed() * 2.0f);
     if (action == GLFW_RELEASE && key == GLFW_KEY_LEFT_SHIFT)
@@ -267,6 +269,11 @@ void Scene::update()
                              resources.getSceneTerrain(), false,
                              projectionMatrix, viewMatrix);
 
+        if (cameraRestriction)
+        {
+            Systems::updateCameraTerrainHeight(bbECS, resources.getSceneTerrain(), mainCamera, 5.0f);
+        }
+
         Systems::drawModels(bbECS, ShaderType::Default, *renderEngine,
                             resources.getSceneModels(), projectionMatrix,
                             viewMatrix);
@@ -405,4 +412,14 @@ void Scene::toggleMenuActive() {
 
 bool Scene::getMenuActive() const {
     return menuActive;
+}
+
+bool Scene::getCameraRestriction() const
+{
+    return cameraRestriction;
+}
+
+void Scene::setCameraRestriction(bool flag)
+{
+    cameraRestriction = flag;
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -159,6 +159,7 @@ void Scene::init()
     glfwSetKeyCallback(window.GetContext(), KeyCallback);
     glfwSetCursorPosCallback(window.GetContext(), MouseCallback);
     glfwSetScrollCallback(window.GetContext(), ScrollCallback);
+    glfwWindowHint(GLFW_DEPTH_BITS, 32);  // Request a 32-bit depth buffer
 
    
     if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress)) {
@@ -167,7 +168,9 @@ void Scene::init()
     }
 
     glEnable(GL_DEPTH_TEST);
-
+    glEnable(GL_POLYGON_OFFSET_FILL);
+    glPolygonOffset(1.0, 1.0);
+    
     mainCamera.SetPosition(1000.0f, 100.0f, 1000.0f);
     mainCamera.SetSensitivity(0.05f);
     mainCamera.SetSpeed(100.0f);
@@ -271,7 +274,7 @@ void Scene::update()
 
         if (cameraRestriction)
         {
-            Systems::updateCameraTerrainHeight(bbECS, resources.getSceneTerrain(), mainCamera, 5.0f);
+            Systems::updateCameraTerrainHeight(bbECS, resources.getSceneTerrain(), mainCamera, 20.0f);
         }
 
         Systems::drawModels(bbECS, ShaderType::Default, *renderEngine,

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.h
@@ -57,6 +57,8 @@ class Scene
     */
     void setWireFrameFlag(bool flag);
 
+    void setCameraRestriction(bool flag);
+
     void setLastX(float lX);
 
     void setLastY(float lY);
@@ -120,6 +122,8 @@ class Scene
     bool getMenuActive() const;
 
     void toggleMenuActive();
+
+    bool getCameraRestriction() const;
    private:
     Window window;
 
@@ -155,4 +159,6 @@ class Scene
 
     float interpolation = 0.f;
     bool menuActive = false;
+
+    bool cameraRestriction = true;
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/Terrain/MainTerrain.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/Terrain/MainTerrain.lua
@@ -11,13 +11,13 @@ Entity = {
             z = 0
         },
         Scale = {
-            x = 1.0,
-            y = 0.25,
-            z = 1.0
+            x = 80.0,
+            y = 25.0,
+            z = 80.0
         }
     },
     Terrain = {
         TerrainPath = "Resources/Heightmaps/heightmap-2.png",
-        TerrainTexturePath = "Resources/Textures/Terrain/terrain-4.png"
+        TerrainTexturePath = "Resources/Textures/Terrain/aerial_rocks.png"
     }
 }


### PR DESCRIPTION
## What problem does this pull request address?
<!-- Give a summary of the problem being fixed or the enhancement being implemented. Tag the issue or task wherever possible. -->

This change adds camera terrain collision back after restructuring the entrypoint so that `Scene` is a standard interface. It had to be removed in that refactor since it was based on a global terrain object. Now it is fully dynamic.

## How does this pull request solve the problem?
<!-- Give a summary of the solution being implemented and any details that will help the reviewer understand the changes. Explain why you chose this approach and any relevant design decisions you made. Are there any consequences beyond the scope of the problem being addressed? -->

This change is implemented by adding a function into `systems` interface which checks for collision with any terrain components that are added into a scene. If there is a value present in any of terrain components which match the current `x` and `z` coordinates of the camera, the camera will be set to the resulting height of that terrain object. There is also an additional optional camera offset that is passed into this function to adjust player/camera height (currently set to `10.0f` by default).

The `scene` interface now contains a `restrictCamera` bool flag which determines whether or not terrain collision is active. This flag is currently set to change if `r` is pressed by the user when running the current scene through the static key callback function.

The concern with calculating terrain collisions in this method is that adding a lot of terrain entities into the scene may prove to negatively affect performance as currently the system has to iterate through all terrain components present to check that camera is within its bounds. Fortunately we are not required to load more than one terrain so performance will not be affected by the specific game implementation for this project.

The camera height translation is based on the model matrices given to the Terrain instances from the components in their scripts. This is done since this transform component is applied to the Terrain when its constructed, and using the model matrix based on the transform component allows for camera collision to be based on the true, real-time translations of the terrain since the transform component values get updated by the systems, and not the raw terrain data itself.

The `updateTransformComponents` function was removed from `Systems` in this PR as well as that function is not being used anywhere and is not necessary.

The Terrain texture was also swapped out in this PR to make the terrain look more visually appealing. Terrain was also scaled up to better suit assignment terrain scale requirements. 



https://github.com/Minywire/Bottlebrush_Engine/assets/77040582/5bf9aa94-29a3-42b0-8ee1-abbc46bffc41


## What testing has been performed?
<!-- Use checkboxes to list tests from your test plan and check them off as they are completed. -->
<!-- If applicable, explain which tests will be done after the pull request is merged. -->
<!-- If no testing is done or applicable, please describe your rationale behind it. -->

- [x] Builds successfully
- [x] Runs successfully
- [x] Camera accurately follow terrain and doesn't jitter when standing still
- [x] Stable and high framerate