### PR TITLE
139 dispatch delay

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
@@ -101,6 +101,16 @@ glm::vec2 NPC::GetVec2Position(ECS& ecs)
     return pos;
 }
 
+void NPC::SetLastPlayerLoc(glm::vec2 loc)
+{ 
+    m_LastPlayerLoc = loc;
+}
+
+glm::vec2& NPC::GetLastPlayerLoc()
+{
+    return m_LastPlayerLoc;
+}
+
 void NPC::SetWaitDuration(float wait)
 {
     m_WaitTimerDuration = wait;

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
@@ -18,7 +18,13 @@ NPC::NPC(const std::filesystem::path& statesPath,
     m_WaitTimeElapsed(0),
     m_PatrolWaitDuration(1),
     m_WaitTimerDuration(0),
-    m_Moving(false)
+    m_Moving(false),
+    m_max_speed(100.f),
+    m_current_speed(0.f),
+    m_acceleration_rate(0.1f),
+    m_deceleration_rate(0.1f),
+    m_direction(1, 1),
+    m_LastMoveTo(0.0f, 0.0f)
 {
 
 }
@@ -35,6 +41,9 @@ void NPC::MoveTo(const glm::vec2& targetPos, ECS& ecs, float offset)
     // MoveTo returns true if it has reached that destination
     m_Moving = !Movement::MoveTo(GetVec2Position(ecs), targetPos, 
         m_current_speed, m_acceleration_rate, m_direction, m_DeltaTime, offset);
+
+    // track last target pos
+    m_LastMoveTo = targetPos;
 }
 
 void NPC::AddWaypoint(glm::vec2 point)
@@ -99,14 +108,10 @@ glm::vec2 NPC::GetVec2Position(ECS& ecs)
     return pos;
 }
 
-void NPC::SetLastPlayerLoc(glm::vec2 loc)
-{ 
-    m_LastPlayerLoc = loc;
-}
 
-glm::vec2& NPC::GetLastPlayerLoc()
+glm::vec2& NPC::GetLastMoveTo()
 {
-    return m_LastPlayerLoc;
+    return m_LastMoveTo;
 }
 
 void NPC::SetWaitDuration(float wait)

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -88,9 +88,10 @@ public:
     /// @return wait time > wait timer
     bool IsWaiting();
 
-    void SetLastPlayerLoc(glm::vec2 loc);
-
-    glm::vec2& GetLastPlayerLoc();
+    /// @author Alan
+    /// @brief gets the last movement command position
+    /// @return a world coord
+    glm::vec2& GetLastMoveTo();
 
     float& GetCurrentSpeed();
 
@@ -117,13 +118,13 @@ private:
     float m_WaitTimerDuration;   // wait timer for miscellanenous reasons
 
     //movement properties
-    float m_max_speed = 100.f;
-    float m_current_speed = 0.f;
-    float m_acceleration_rate = 0.1f;
-    float m_deceleration_rate = 0.1f;
-    glm::vec2 m_direction = {1, 1}; // direction that the NPC is facing
+    float m_max_speed;
+    float m_current_speed;
+    float m_acceleration_rate;
+    float m_deceleration_rate;
+    glm::vec2 m_direction; // direction that the NPC is facing
 
-    glm::vec2 m_LastPlayerLoc = {0, 0}; // last known player location
+    glm::vec2 m_LastMoveTo; // last movement command
 
     
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -69,12 +69,6 @@ public:
     void StopMoving();
 
     /// @author Alan
-    /// @brief gets transform component and returns in position in (x,z) format
-    /// @param ecs register to get transform component
-    /// @return floor position (x,z)
-    glm::vec2 GetVec2Position(ECS& ecs);
-
-    /// @author Alan
     /// @brief set a wait timer
     /// @param wait duration in seconds
     void SetWaitDuration(float wait);
@@ -123,6 +117,12 @@ private:
     float m_acceleration_rate;
     float m_deceleration_rate;
     glm::vec2 m_direction; // direction that the NPC is facing
+
+    /// @author Alan
+    /// @brief gets transform component and returns in position in (x,z) format
+    /// @param ecs register to get transform component
+    /// @return floor position (x,z)
+    glm::vec2 GetVec2Position(ECS& ecs);
 
     glm::vec2 m_LastMoveTo; // last movement command
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -69,6 +69,12 @@ public:
     void StopMoving();
 
     /// @author Alan
+    /// @brief gets transform component and returns in position in (x,z) format
+    /// @param ecs register to get transform component
+    /// @return floor position (x,z)
+    glm::vec2 GetVec2Position(ECS& ecs);
+
+    /// @author Alan
     /// @brief set a wait timer
     /// @param wait duration in seconds
     void SetWaitDuration(float wait);
@@ -117,12 +123,6 @@ private:
     float m_acceleration_rate;
     float m_deceleration_rate;
     glm::vec2 m_direction; // direction that the NPC is facing
-
-    /// @author Alan
-    /// @brief gets transform component and returns in position in (x,z) format
-    /// @param ecs register to get transform component
-    /// @return floor position (x,z)
-    glm::vec2 GetVec2Position(ECS& ecs);
 
     glm::vec2 m_LastMoveTo; // last movement command
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -70,6 +70,12 @@ public:
     void StopMoving();
 
     /// @author Alan
+    /// @brief gets transform component and returns in position in (x,z) format
+    /// @param ecs register to get transform component
+    /// @return floor position (x,z)
+    glm::vec2 GetVec2Position(ECS& ecs);
+
+    /// @author Alan
     /// @brief set a wait timer
     /// @param wait duration in seconds
     void SetWaitDuration(float wait);
@@ -82,6 +88,10 @@ public:
     /// @brief sees if there is a wait timer
     /// @return wait time > wait timer
     bool IsWaiting();
+
+    void SetLastPlayerLoc(glm::vec2 loc);
+
+    glm::vec2& GetLastPlayerLoc();
 
     float& GetCurrentSpeed();
 
@@ -114,9 +124,7 @@ private:
     float m_deceleration_rate = 0.1f;
     glm::vec2 m_direction = {1, 1}; // direction that the NPC is facing
 
-    /// @author Alan
-    /// @brief gets transform component and returns in position in (x,z) format
-    /// @param ecs register to get transform component
-    /// @return floor position (x,z)
-    glm::vec2 GetVec2Position(ECS& ecs);
+    glm::vec2 m_LastPlayerLoc = {0, 0}; // last known player location
+
+    
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -72,6 +72,7 @@ void Systems::RegisterAIFunctions(ECS& ecs, sol::state & lua_state, const Camera
     AIScripts::registerScriptedFSM(lua_state);
     AIScripts::registerScriptedNPC(lua_state, ecs, player);
     AIScripts::registerScriptedGLM(lua_state);
+    AIScripts::registerScriptedMessage(lua_state);
 }
 
 void Systems::setLight(RenderEngine & renderEngine, const ShaderType & shaderType, glm::mat4 view)
@@ -245,9 +246,6 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
             if (npc.GetCurrentSpeed() <= npc.GetMaxSpeed()) 
                 npc.GetCurrentSpeed() += npc.GetAcceleration();
         }
-        
-        // @Debug Line
-        //std::cout << "speed: " << move.current_speed << std::endl;
 
         // move in its current direction by its current speed
         transform.position.x += npc.GetDirection().x * deltaTime * npc.GetCurrentSpeed();

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -5,6 +5,8 @@
 #include "Systems.h"
 #include "BBScript.h"
 #include "RegisterAIScripts.h"
+#include "EventDispatcher.h"
+#include "Singleton.h"
 
 void Systems::generateModelFromComponent(const ModelComponent & modelComp, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels)
 {
@@ -281,4 +283,7 @@ void Systems::updateAI(ECS& ecs, sol::state& lua_state, float deltaTime) {
 
       aic.npc.Update(lua_state, deltaTime);
     }
+
+    // dispatch any delayed messages
+    Singleton<EventDispatcher>::Instance().DispatchDelayedMessages(lua_state, deltaTime);
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/EventDispatcher.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/EventDispatcher.cpp
@@ -6,7 +6,37 @@
 
 void EventDispatcher::DispatchMessage(sol::state& lua_state, Message& msg, NPC& receiver)
 {
-    Send(lua_state, msg, receiver);
+    if (msg.GetDelayTime() == 0) {
+        std::cout << "Instant Message" << std::endl;
+        Send(lua_state, msg, receiver);
+    } else {
+        std::cout << "Store Message" << std::endl;
+        m_MessageQue.insert(std::make_pair(msg, receiver));
+    }
+}
+
+void EventDispatcher::DispatchDelayedMessages(sol::state& lua_state, float deltaTime) 
+{
+    // if que is empty reset timer and return
+    if (m_MessageQue.empty()) 
+    {
+        m_TimeElapsed = 0;
+        return;
+    } 
+    else // else increment by deltaTime
+    { 
+        m_TimeElapsed += deltaTime;
+    }
+
+    while (!m_MessageQue.empty() && m_MessageQue.begin()->first.GetDelayTime() <
+           m_TimeElapsed) 
+    {
+        auto msg = m_MessageQue.begin()->first;
+        auto& receiver = m_MessageQue.begin()->second;
+        std::cout << "Sending Stored Message" << std::endl;
+        Send(lua_state, msg, receiver);
+        m_MessageQue.erase(m_MessageQue.begin());
+    }
 }
 
 void EventDispatcher::Send(sol::state& lua_state, Message& msg, NPC& receiver) 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/EventDispatcher.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/EventDispatcher.cpp
@@ -6,13 +6,11 @@
 
 void EventDispatcher::DispatchMessage(sol::state& lua_state, Message& msg, NPC& receiver)
 {
-    if (msg.GetDelayTime() == 0) {
-        std::cout << "Instant Message" << std::endl;
-        Send(lua_state, msg, receiver);
-    } else {
-        std::cout << "Store Message" << std::endl;
-        m_MessageQue.insert(std::make_pair(msg, receiver));
-    }
+    // if no delay, send the message instantly
+    if (msg.GetDelayTime() == 0) Send(lua_state, msg, receiver);
+    // else store the message
+    else m_MessageQue.insert(std::make_pair(msg, receiver));
+    
 }
 
 void EventDispatcher::DispatchDelayedMessages(sol::state& lua_state, float deltaTime) 
@@ -28,14 +26,14 @@ void EventDispatcher::DispatchDelayedMessages(sol::state& lua_state, float delta
         m_TimeElapsed += deltaTime;
     }
 
+    // send all messages that the timer has elapsed, delete as we move to next message
     while (!m_MessageQue.empty() && m_MessageQue.begin()->first.GetDelayTime() <
            m_TimeElapsed) 
     {
         auto msg = m_MessageQue.begin()->first;
         auto& receiver = m_MessageQue.begin()->second;
-        std::cout << "Sending Stored Message" << std::endl;
         Send(lua_state, msg, receiver);
-        m_MessageQue.erase(m_MessageQue.begin());
+        m_MessageQue.erase(m_MessageQue.begin()); // erase current message after sending
     }
 }
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/EventDispatcher.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/EventDispatcher.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "Message.h"
 #include "sol/sol.hpp"
 #include "NPC.h"
@@ -14,7 +16,9 @@ class EventDispatcher
 {
 public:
     void DispatchMessage(sol::state& lua_state, Message& msg, NPC& receiver);
-
+    void DispatchDelayedMessages(sol::state& lua_state, float deltaTime);
 private:
+    float m_TimeElapsed = 0; // used to check if delayed messages are past the timer.
+    std::multimap<Message, NPC> m_MessageQue; // que for delayed messages
     void Send(sol::state& lua_state, Message& msg, NPC& receiver);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.cpp
@@ -4,7 +4,8 @@
 
 #include "Message.h"
 
-Message::Message(std::string event, NPC* sender) : m_Sender(sender), m_Event(event) 
+Message::Message(std::string event, NPC* sender, float delayTime)
+    : m_Sender(sender), m_Event(event), m_DelayTime(delayTime) 
 {
 
 }
@@ -17,4 +18,15 @@ NPC& Message::GetSender()
 std::string& Message::GetEvent()
 {
 	return m_Event;
+}
+
+const float Message::GetDelayTime() const
+{
+	return m_DelayTime;
+}
+
+
+bool Message::operator<(const Message& otherMsg) const
+{ 
+	return m_DelayTime < otherMsg.m_DelayTime;
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.cpp
@@ -14,7 +14,7 @@ NPC* Message::GetSender()
 	return m_Sender; 
 }
 
-Event Message::GetEvent()
+std::string& Message::GetEvent()
 {
 	return m_Event;
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.cpp
@@ -15,3 +15,8 @@ NPC* Message::GetSender()
 {
 	return m_Sender;
 }
+
+Event Message::GetEvent()
+{
+	return m_Event;
+}

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.h
@@ -13,11 +13,18 @@ class NPC;
 class Message
 {
 public:
-    Message(std::string event, NPC* sender);
+    Message(std::string event, NPC* sender, float delayTime);
 
     std::string& GetEvent();
     NPC& GetSender();
+    const float GetDelayTime() const;
+
+    /// @author Alan
+    /// @brief used to sort in order in Event Dispatcher if message is delayed
+    /// @return if this message takes less time than another message
+    bool operator<(const Message& otherMsg) const;
 private:
-    std::string m_Event;
-    NPC* m_Sender;
+    std::string m_Event; // event to send
+    NPC* m_Sender; // the sending NPC
+    const float m_DelayTime; // adding delay time to sending the message
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.h
@@ -16,7 +16,7 @@ public:
     Message(std::string event, NPC* sender);
 
     NPC* GetSender();
-    Event GetEvent();
+    std::string& GetEvent();
 private:
     std::string m_Event;
     NPC* m_Sender;

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBEvent/Message.h
@@ -19,6 +19,7 @@ public:
     Message(Event event, NPC* sender);
 
     NPC* GetSender();
+    Event GetEvent();
 private:
     Event m_Event;
     NPC* m_Sender;

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -24,7 +24,6 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
         "SetWaitDuration", &NPC::SetWaitDuration,
         "IsWaiting", &NPC::IsWaiting,
         "ClearWaitDuration", &NPC::ClearWaitDuration,
-        "GetPosition", &NPC::GetVec2Position,
         "GetLastMoveTo", &NPC::GetLastMoveTo,
         "IsMoving", &NPC::IsMoving
     );

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -25,7 +25,7 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
         "IsWaiting", &NPC::IsWaiting,
         "ClearWaitDuration", &NPC::ClearWaitDuration,
         "GetPosition", &NPC::GetVec2Position,
-        "GetLastPlayerLocation", &NPC::GetLastPlayerLoc,
+        "GetLastMoveTo", &NPC::GetLastMoveTo,
         "IsMoving", &NPC::IsMoving
     );
 
@@ -36,7 +36,6 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
     movementTable["ChasePlayer"] = [&ecs, &player](NPC& npc) 
     { 
         glm::vec2 pos = {player.GetPositionX(), player.GetPositionZ()};
-        npc.SetLastPlayerLoc(pos);
         npc.MoveTo(pos, ecs); 
         return npc.IsMoving();
     };
@@ -47,7 +46,7 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
     detectionTable["InMessageRange"] = [&ecs](NPC& npc, Message& msg, float range)
     {
         glm::vec2 curPos = npc.GetVec2Position(ecs);
-        glm::vec2 theirPos = msg.GetSender()->GetVec2Position(ecs);
+        glm::vec2 theirPos = msg.GetSender().GetLastMoveTo();
         float distance = glm::length(theirPos - curPos);
         return distance < range;
     };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -69,15 +69,8 @@ void registerScriptedGLM(sol::state& lua_state) {
 }
 
 void registerScriptedMessage(sol::state& lua_state) {
-    // register Event enum
-    lua_state.new_enum("Event",
-        "PlayerSpotted", Event::PLAYERSPOTTED
-    );
-
     // register Message system
     lua_state.new_usertype<Message>("Message",
-        sol::call_constructor,
-        sol::constructors<Message(Event, NPC*)>(),
         "GetEvent", &Message::GetEvent,
         "GetSender", &Message::GetSender
     );

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -45,17 +45,21 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
 
     // register EventDispatcher table functions that depend on lua_state
     auto dispatchTable = lua_state["Dispatch"].get_or_create<sol::table>();
-    dispatchTable["SendMessage"] = [&ecs, &lua_state](std::string event, NPC& npc) 
+    dispatchTable["SendMessage"] = [&ecs, &lua_state](std::string event, NPC& npc, float delayTime = 0) 
     {
-        Message msg(event, &npc);
+        Message msg(event, &npc, delayTime);
         npc.SendMessage(ecs, lua_state, msg);
     };
-    dispatchTable["InMessageRange"] = [&ecs](NPC& npc, Message& msg,
-                                              float range) {
+    dispatchTable["InMessageRange"] = [&ecs](NPC& npc, Message& msg, float range) 
+    {
         glm::vec2 curPos = npc.GetVec2Position(ecs);
-        glm::vec2 theirPos = msg.GetSender().GetLastMoveTo();
+        glm::vec2 theirPos = msg.GetSender().GetVec2Position(ecs);
         float distance = glm::length(theirPos - curPos);
         return distance < range;
+    };
+    dispatchTable["GetSenderLocation"] = [&ecs](Message& msg)
+    {
+        return msg.GetSender().GetVec2Position(ecs);
     };
 }
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -31,7 +31,7 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
     // register movement functions that depend on transform component
     auto movementTable = lua_state["Movement"].get_or_create<sol::table>();
     movementTable["Patrol"] = [&ecs](NPC& npc) { npc.Patrol(ecs); };
-    movementTable["MoveTo"] = [&ecs](NPC& npc, glm::vec2& vec2) { npc.MoveTo(vec2, ecs); };
+    movementTable["MoveTo"] = [&ecs](NPC& npc, const glm::vec2& vec2) { npc.MoveTo(vec2, ecs); };
     movementTable["ChasePlayer"] = [&ecs, &player](NPC& npc) 
     { 
         glm::vec2 pos = {player.GetPositionX(), player.GetPositionZ()};

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -43,13 +43,6 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
     // register detection functions that depend on transform component
     auto detectionTable = lua_state["Detection"].get_or_create<sol::table>();
     detectionTable["SeePlayer"] = [&player, &ecs](NPC& npc) { return npc.SeePlayer(glm::vec2(player.GetPositionX(), player.GetPositionZ()), ecs); };
-    detectionTable["InMessageRange"] = [&ecs](NPC& npc, Message& msg, float range)
-    {
-        glm::vec2 curPos = npc.GetVec2Position(ecs);
-        glm::vec2 theirPos = msg.GetSender().GetLastMoveTo();
-        float distance = glm::length(theirPos - curPos);
-        return distance < range;
-    };
 
     // register EventDispatcher table functions that depend on lua_state
     auto dispatchTable = lua_state["Dispatch"].get_or_create<sol::table>();
@@ -57,6 +50,13 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player) 
     {
         Message msg(event, &npc);
         npc.SendMessage(ecs, lua_state, msg);
+    };
+    dispatchTable["InMessageRange"] = [&ecs](NPC& npc, Message& msg,
+                                              float range) {
+        glm::vec2 curPos = npc.GetVec2Position(ecs);
+        glm::vec2 theirPos = msg.GetSender().GetLastMoveTo();
+        float distance = glm::length(theirPos - curPos);
+        return distance < range;
     };
 }
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.h
@@ -14,5 +14,6 @@ namespace AIScripts {
 void registerScriptedFSM(sol::state& lua_state);
 void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player);
 void registerScriptedGLM(sol::state& lua_state);
+void registerScriptedMessage(sol::state& lua_state);
 
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
@@ -65,7 +65,7 @@ Chase = {
 	end,
 
 	Update = function(NPC)
-		Movement.MoveTo(NPC, NPC:GetLastPlayerLocation());
+		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
 			Dispatch.SendMessage("PlayerSpotted", NPC);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
@@ -17,6 +17,11 @@ Global = {
 	end,
 	
 	onMessage = function(NPC, Message)
+		--if NPC:WithinMessageRange(Message, 100.0) then
+		--	if Message.GetEvent == Event.PlayerSpotted then
+		--		FSM.ChangeState(NPC, "Chase");
+		--	end
+		--end
 		print("Message Received");
 	end
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
@@ -19,7 +19,7 @@ Global = {
 	onMessage = function(NPC, Message)
 		if Detection.InMessageRange(NPC, Message, 500.0) then
 			print("Lua: Message Received");
-			if Message:GetEvent() == Event.PlayerSpotted then
+			if Message:GetEvent() == "PlayerSpotted" then
 				FSM.ChangeState(NPC, "Chase");
 			else
 				print("Lua: hasnt been spotted")
@@ -68,7 +68,7 @@ Chase = {
 		Movement.MoveTo(NPC, NPC:GetLastPlayerLocation());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
-			Dispatch.SendMessage(Message(Event.PlayerSpotted, NPC));
+			Dispatch.SendMessage("PlayerSpotted", NPC);
 		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
 			FSM.ChangeState(NPC, "Idle");
 		end

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
@@ -17,11 +17,12 @@ Global = {
 	end,
 	
 	onMessage = function(NPC, Message)
-		--if Dispatch.InMessageRange(NPC, Message, 1000.0) then
+		if Dispatch.InMessageRange(NPC, Message, 1000.0) then
 			if Message:GetEvent() == "PlayerSpotted" then
-				FSM.ChangeState(NPC, "Chase");
+				Movement.MoveTo(NPC, Dispatch.GetSenderLocation(Message))
+				FSM.ChangeState(NPC, "Investigate");
 			end
-		--end
+		end
 	end
 }
 
@@ -38,7 +39,7 @@ Idle = {
 
 	Update = function(NPC)
 		if Detection.SeePlayer(NPC) then
-			Dispatch.SendMessage("PlayerSpotted", NPC, 5.0);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
 			FSM.ChangeState(NPC, "Chase");
 		end	
 	end,
@@ -62,7 +63,32 @@ Chase = {
 		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
-			Dispatch.SendMessage("PlayerSpotted", NPC, 5.0);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
+		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
+			FSM.ChangeState(NPC, "Idle");
+		end
+	end,
+
+	onExit = function(NPC)
+
+	end
+}
+
+-------------------------------------------------------------------------------
+
+-- create the investigate state
+
+-------------------------------------------------------------------------------
+Investigate = {
+	onEnter = function(NPC)
+		print("Investigate")
+	end,
+
+	Update = function(NPC)
+		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
+		if Detection.SeePlayer(NPC) then
+			Movement.ChasePlayer(NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
 		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
 			FSM.ChangeState(NPC, "Idle");
 		end

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
@@ -17,11 +17,11 @@ Global = {
 	end,
 	
 	onMessage = function(NPC, Message)
-		if Dispatch.InMessageRange(NPC, Message, 500.0) then
+		--if Dispatch.InMessageRange(NPC, Message, 1000.0) then
 			if Message:GetEvent() == "PlayerSpotted" then
 				FSM.ChangeState(NPC, "Chase");
 			end
-		end
+		--end
 	end
 }
 
@@ -38,7 +38,7 @@ Idle = {
 
 	Update = function(NPC)
 		if Detection.SeePlayer(NPC) then
-			Dispatch.SendMessage("PlayerSpotted", NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 5.0);
 			FSM.ChangeState(NPC, "Chase");
 		end	
 	end,
@@ -62,7 +62,7 @@ Chase = {
 		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
-			Dispatch.SendMessage("PlayerSpotted", NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 5.0);
 		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
 			FSM.ChangeState(NPC, "Idle");
 		end

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/IdlerStates.lua
@@ -17,12 +17,9 @@ Global = {
 	end,
 	
 	onMessage = function(NPC, Message)
-		if Detection.InMessageRange(NPC, Message, 500.0) then
-			print("Lua: Message Received");
+		if Dispatch.InMessageRange(NPC, Message, 500.0) then
 			if Message:GetEvent() == "PlayerSpotted" then
 				FSM.ChangeState(NPC, "Chase");
-			else
-				print("Lua: hasnt been spotted")
 			end
 		end
 	end
@@ -35,7 +32,6 @@ Global = {
 -------------------------------------------------------------------------------
 Idle = {
 	onEnter = function(NPC)
-		print("Entered Idle state");
 		NPC:StopMoving();
 		NPC:SetWaitDuration(5.0);
 	end,
@@ -48,7 +44,6 @@ Idle = {
 	end,
 
 	onExit = function(NPC)
-		print("Exiting Idle state");
 		NPC:ClearWaitDuration();
 	end
 }
@@ -60,7 +55,6 @@ Idle = {
 -------------------------------------------------------------------------------
 Chase = {
 	onEnter = function(NPC)
-		print("Entered Chase state");
 		Movement.ChasePlayer(NPC);
 	end,
 
@@ -75,6 +69,6 @@ Chase = {
 	end,
 
 	onExit = function(NPC)
-		print("Exiting Chase state");
+
 	end
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
@@ -17,13 +17,12 @@ Global = {
 	end,
 
 	onMessage = function(NPC, Message)
-		print("Messaged")
-		--if Dispatch.InMessageRange(NPC, Message, 1000.0) then
+		if Dispatch.InMessageRange(NPC, Message, 1000.0) then
 			if Message:GetEvent() == "PlayerSpotted" then
 				Movement.MoveTo(NPC, Dispatch.GetSenderLocation(Message))
 				FSM.ChangeState(NPC, "Investigate");
 			end
-		--end
+		end
 	end
 }
 
@@ -66,7 +65,7 @@ Patrol = {
 	Update = function(NPC)
 		Movement.Patrol(NPC);
 		if Detection.SeePlayer(NPC) then
-			Dispatch.SendMessage("PlayerSpotted", NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
 			FSM.ChangeState(NPC, "Chase");
 		end	
 	end,
@@ -83,7 +82,6 @@ Patrol = {
 -------------------------------------------------------------------------------
 Chase = {
 	onEnter = function(NPC)
-		print("Chasing")
 		Movement.ChasePlayer(NPC);
 	end,
 
@@ -91,7 +89,7 @@ Chase = {
 		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
-			Dispatch.SendMessage("PlayerSpotted", NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
 		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
 			FSM.ChangeState(NPC, "Idle");
 		end
@@ -109,14 +107,14 @@ Chase = {
 -------------------------------------------------------------------------------
 Investigate = {
 	onEnter = function(NPC)
-		print("Investigate")
+
 	end,
 
 	Update = function(NPC)
 		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
-			Dispatch.SendMessage("PlayerSpotted", NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
 		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
 			FSM.ChangeState(NPC, "Idle");
 		end

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
@@ -17,12 +17,9 @@ Global = {
 	end,
 
 	onMessage = function(NPC, Message)
-		if Detection.InMessageRange(NPC, Message, 500.0) then
-			print("Lua: Message Received");
+		if Dispatch.InMessageRange(NPC, Message, 500.0) then
 			if Message:GetEvent() == Event.PlayerSpotted then
 				FSM.ChangeState(NPC, "Chase");
-			else
-				print("Lua: hasnt been spotted")
 			end
 		end
 	end
@@ -35,7 +32,6 @@ Global = {
 -------------------------------------------------------------------------------
 Idle = {
 	onEnter = function(NPC)
-		print("Entered Idle state");
 		NPC:StopMoving();
 		NPC:SetWaitDuration(5.0);
 	end,
@@ -51,7 +47,7 @@ Idle = {
 	end,
 
 	onExit = function(NPC)
-		print("Exiting Idle state");
+
 	end
 }
 
@@ -62,7 +58,6 @@ Idle = {
 -------------------------------------------------------------------------------
 Patrol = {
 	onEnter = function(NPC)
-		print("Entered Patrol state");
 		NPC:SetWaitDuration(3.0);
 	end,
 
@@ -75,7 +70,6 @@ Patrol = {
 	end,
 
 	onExit = function(NPC)
-		print("Exiting Patrol state");
 		NPC:ClearWaitDuration();
 	end
 }
@@ -87,7 +81,6 @@ Patrol = {
 -------------------------------------------------------------------------------
 Chase = {
 	onEnter = function(NPC)
-		print("Entered Chase state");
 		Movement.ChasePlayer(NPC);
 	end,
 
@@ -102,6 +95,6 @@ Chase = {
 	end,
 
 	onExit = function(NPC)
-		print("Exiting Chase state");
+
 	end
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
@@ -45,6 +45,7 @@ Idle = {
 			FSM.ChangeState(NPC, "Patrol");
 		end
 		if Detection.SeePlayer(NPC) then
+			Dispatch.SendMessage("PlayerSpotted", NPC);
 			FSM.ChangeState(NPC, "Chase");
 		end	
 	end,
@@ -94,7 +95,7 @@ Chase = {
 		Movement.MoveTo(NPC, NPC:GetLastPlayerLocation());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
-			Dispatch.SendMessage(Message(Event.PlayerSpotted, NPC));
+			Dispatch.SendMessage("PlayerSpotted", NPC);
 		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
 			FSM.ChangeState(NPC, "Idle");
 		end

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
@@ -92,7 +92,7 @@ Chase = {
 	end,
 
 	Update = function(NPC)
-		Movement.MoveTo(NPC, NPC:GetLastPlayerLocation());
+		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC) then
 			Movement.ChasePlayer(NPC);
 			Dispatch.SendMessage("PlayerSpotted", NPC);

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/PatrollerStates.lua
@@ -17,11 +17,13 @@ Global = {
 	end,
 
 	onMessage = function(NPC, Message)
-		if Dispatch.InMessageRange(NPC, Message, 500.0) then
-			if Message:GetEvent() == Event.PlayerSpotted then
-				FSM.ChangeState(NPC, "Chase");
+		print("Messaged")
+		--if Dispatch.InMessageRange(NPC, Message, 1000.0) then
+			if Message:GetEvent() == "PlayerSpotted" then
+				Movement.MoveTo(NPC, Dispatch.GetSenderLocation(Message))
+				FSM.ChangeState(NPC, "Investigate");
 			end
-		end
+		--end
 	end
 }
 
@@ -81,7 +83,33 @@ Patrol = {
 -------------------------------------------------------------------------------
 Chase = {
 	onEnter = function(NPC)
+		print("Chasing")
 		Movement.ChasePlayer(NPC);
+	end,
+
+	Update = function(NPC)
+		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
+		if Detection.SeePlayer(NPC) then
+			Movement.ChasePlayer(NPC);
+			Dispatch.SendMessage("PlayerSpotted", NPC);
+		elseif not Detection.SeePlayer(NPC) and not NPC:IsMoving() then
+			FSM.ChangeState(NPC, "Idle");
+		end
+	end,
+
+	onExit = function(NPC)
+
+	end
+}
+
+-------------------------------------------------------------------------------
+
+-- create the investigate state
+
+-------------------------------------------------------------------------------
+Investigate = {
+	onEnter = function(NPC)
+		print("Investigate")
 	end,
 
 	Update = function(NPC)


### PR DESCRIPTION
## What problem does this pull request address?
To have some delay messaging functionality for the AI. Additionally there needed to be a get sender position from the message functionality to the scripts.

## How does this pull request solve the problem?
Event Dispatcher keeps a record of elapsed time if there is a delayed message that it has stored. Dispatching delayed messages are checked on ai update. The messages are sent after the delay time has elapsed.

AI scripts have access to a `GetSenderLocation` from the message, and I added an Investigation state to travel to that particular location

## What testing has been performed?

- [x] Added a delay in the message


https://github.com/Minywire/Bottlebrush_Engine/assets/87167180/6fa4acc5-9e34-45cc-9b52-935a7b4a0752



- [x] NPCs travel to the message location rather than chase the player after a delayed message 


https://github.com/Minywire/Bottlebrush_Engine/assets/87167180/70dc14a8-8a8b-463c-bf74-950dc2c98d3e



- [x] Builds successfully
- [x] Runs successfully
