### PR TITLE
Get Terrain Height at Specified Coordinates in Scripts

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <sol/sol.hpp>
 #include <ECS.h>
+#include <BBResourceManager.hpp>
 
 class EntityFactory {
 public:
@@ -17,7 +18,7 @@ public:
      * @param lua_file The specified Lua file to create the entity from
      * @return created entity
      */
-    Entity create_from_file(ECS &ecs, sol::state &lua_state, const std::filesystem::path &lua_file);
+    Entity create_from_file(ECS &ecs, sol::state &lua_state, const std::filesystem::path &lua_file, BBResourceManager & resources);
 
     /**
      *
@@ -29,7 +30,7 @@ public:
      * @param zPos z translate
      * @return created entity
      */
-    Entity create_from_file(ECS &ecs, sol::state &lua_state, const std::filesystem::path &lua_file, float xPos, float yPos, float zPos);
+    Entity create_from_file(ECS &ecs, sol::state &lua_state, const std::filesystem::path &lua_file, BBResourceManager & resources, float xPos, float yPos, float zPos);
 
 private:
     /**
@@ -38,7 +39,7 @@ private:
      * @param entity entity to add components to
      * @param table tables
      */
-    void load_components(ECS &ecs, Entity &entity, const sol::table &table);
+    void load_components(ECS &ecs, Entity &entity, const sol::table &table, BBResourceManager & resources);
 
     /**
      * @param ecs  The ecs to load components from
@@ -48,7 +49,7 @@ private:
      * @param yPos y translate
      * @param zPos z translate
      */
-    void load_components(ECS &ecs, Entity &entity, const sol::table &table, float xPos, float yPos, float zPos);
+    void load_components(ECS &ecs, Entity &entity, const sol::table &table, BBResourceManager & resources, float xPos, float yPos, float zPos);
 
     /**
      *
@@ -74,7 +75,7 @@ private:
      * @param entity the entity to attach to
      * @param model the model table to compare against
      */
-    void loadModel(ECS& ecs, Entity &entity, const sol::table &model);
+    void loadModel(ECS& ecs, Entity &entity, const sol::table &model, BBResourceManager & resources);
 
     /**
      *
@@ -89,12 +90,12 @@ private:
      * @param entity the entity to attach to
      * @param terrain the terrain table to compare against
     */
-    void loadTerrain(ECS &ecs, Entity &entity, const sol::table &terrain);
+    void loadTerrain(ECS &ecs, Entity &entity, const sol::table &terrain, BBResourceManager & resources);
 
     /**
      *  @param ecs the ecs registry to load model component from
      * @param entity the entity to attach to
      * @param MD2 the MD2 table to compare against
      */
-    void loadMD2(ECS &ecs, Entity &entity, const sol::table &MD2);
+    void loadMD2(ECS &ecs, Entity &entity, const sol::table &MD2, BBResourceManager & resources);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -6,67 +6,6 @@
 #include "BBScript.h"
 #include "RegisterAIScripts.h"
 
-void Systems::generateModelFromComponent(const ModelComponent & modelComp, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels)
-{
-    if(sceneModels.find(modelComp.model_path) == sceneModels.end())
-    {
-        sceneModels.emplace(std::pair<std::string, std::unique_ptr<Model>>(modelComp.model_path, GraphicsFactory<GraphicsAPI::OpenGL>::CreateModel(modelComp.model_path, modelComp.material_path)));
-    }
-}
-
-void Systems::generateMD2ModelFromComponent(const MD2Component & modelComp, std::unordered_map<std::string, BBMD2> & sceneMD2Models)
-{
-    if(!sceneMD2Models.contains(modelComp.model_path))
-    {
-        sceneMD2Models.emplace(std::pair<std::string, BBMD2>(modelComp.model_path, BBMD2(modelComp.model_path, modelComp.texture_path)));
-    }
-}
-
-void Systems::generateTerrainFromComponent(const TerrainComponent & terrainComp, const TransformComponent & terrainTransform, std::unordered_map<std::string, Terrain> & sceneTerrain) 
-{
-    if(!sceneTerrain.contains(terrainComp.terrain_path))
-    {
-        sceneTerrain.emplace(std::pair<std::string, Terrain>(terrainComp.terrain_path, Terrain(terrainComp.terrain_path, terrainComp.terrain_texture, terrainTransform.scale, terrainTransform.position)));
-    }
-}
-
-void Systems::createModelComponents(ECS &ecs, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels)
-{
-    auto group = ecs.GetAllEntitiesWith<ModelComponent>(); //the container with all the matching entities
-
-    for(auto entity : group)
-    {
-        auto& currentModelComponent = group.get<ModelComponent>(entity);
-
-        generateModelFromComponent(currentModelComponent, sceneModels);
-    }
-}
-
-void Systems::createMD2ModelComponents(ECS &ecs, std::unordered_map<std::string, BBMD2> & sceneMD2Models)
-{
-    auto group = ecs.GetAllEntitiesWith<MD2Component>(); //the container with all the matching entities
-
-    for(auto entity : group)
-    {
-        auto& currentModelComponent = group.get<MD2Component>(entity);
-
-        generateMD2ModelFromComponent(currentModelComponent, sceneMD2Models);
-    }
-}
-
-void Systems::createTerrainComponents(ECS &ecs, std::unordered_map<std::string, Terrain> & sceneTerrain)
-{
-    auto group = ecs.GetAllEntitiesWith<TransformComponent, TerrainComponent>(); //the container with all the matching entities
-
-    for(auto entity : group)
-    {
-        auto& currentTerrainComponent = group.get<TerrainComponent>(entity);
-        auto& currentTransform = group.get<TransformComponent>(entity);
-
-        generateTerrainFromComponent(currentTerrainComponent, currentTransform, sceneTerrain);
-    }
-}
-
 void Systems::RegisterAIFunctions(ECS& ecs, sol::state & lua_state, const Camera& player) 
 {
     AIScripts::registerScriptedFSM(lua_state);
@@ -286,3 +225,22 @@ void Systems::updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map
         } 
     }
 }
+
+const std::optional<float> Systems::getTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain>& terrains, float x, float z)
+{
+    auto group = ecs.GetAllEntitiesWith<TerrainComponent>();
+
+    for (auto entity : group) 
+    {
+        const auto& currentTerrainComp = group.get<TerrainComponent>(entity);
+        const auto& currentTerrain = terrains.at(currentTerrainComp.terrain_path);
+
+        const std::optional<float> terrain_height = currentTerrain.GetHeight(x, z);
+
+        if (terrain_height.has_value()) 
+        {
+            return terrain_height;
+        }
+    }
+    return std::nullopt;
+}   

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -21,49 +21,6 @@
 class Systems {
 public:
     /**
-     * Generates a model from an existing component into a map structure holding model render data
-     * @param modelComp The model component to generate the model from
-     * @param sceneModels The scene structure holding all of the model data
-     */
-    static void generateModelFromComponent(const ModelComponent & modelComp, std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels);
-
-    /**
-     * Generates an MD2 model from an existing component into a map structure holding MD2 model render data
-     * @param modelComp The model component to generate the model from
-     * @param sceneMD2Models The scene structure holding all of the MD2 model data
-     */
-    void generateMD2ModelFromComponent(const MD2Component & modelComp, std::unordered_map<std::string, BBMD2> & sceneMD2Models);
-
-    /**
-     * Generates a terrain mesh from an existing component into a map structure holding
-     * terrain render data
-     * @param modelComp The model component to generate the model from
-     * @param sceneModels The scene structure holding all of the model data
-     */
-    void generateTerrainFromComponent(const TerrainComponent & terrainComp, const TransformComponent & terrainTransform, std::unordered_map<std::string, Terrain> & sceneTerrain); 
-
-    /**
-     *
-     * @param ecs The registry for which to create the model components onto the entity
-     * @param sceneModels The structure containing the models in a scene
-     */
-    void createModelComponents(ECS &ecs, std::unordered_map<std::string, std::unique_ptr<Model>>& sceneModels);
-
-     /**
-     *
-     * @param ecs The registry for which to create the model components onto the
-     * entity
-     * @param sceneModels The structure containing the models in a scene
-     */
-    void createTerrainComponents(ECS &ecs, std::unordered_map<std::string, Terrain> &sceneTerrain);
-
-    /**
-     * @param ecs The registry for which to create the model components onto the entity
-     * @param sceneMD2Models The structure containing the MD2 models in a scene
-     */
-    void createMD2ModelComponents(ECS &ecs, std::unordered_map<std::string, BBMD2> & sceneMD2Models);
-
-    /**
      * @author Alan
      * @brief Registers the appropriate AI functions to lua
      * @param ecs The registry to pass into the lua registers to dependencyinject into NPC
@@ -145,4 +102,6 @@ public:
     static void updateAI(ECS &ecs, sol::state &lua_state, float deltaTime);
 
     static void updateCameraTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, Camera & camera, float offset_y = 10.0f);
+    
+    static const std::optional<float> getTerrainHeight(const ECS& ecs, const std::unordered_map<std::string, Terrain> & terrains, float x, float z);
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -51,7 +51,7 @@ void MouseCallback(Window::WindowContext window, double pos_x, double pos_y)
     scene->getCamera().ProcessMouseMovement(x_offset, y_offset);
 }
 
-void ScrollCallback(Window::WindowContext window, double x_offset, double y_offset) \
+void ScrollCallback(Window::WindowContext window, double x_offset, double y_offset)
 {
     auto* data = glfwGetWindowUserPointer(window);
     auto* scene = reinterpret_cast<Scene*>(data);
@@ -87,12 +87,17 @@ void Scene::ProcessInput(float deltaTime) {
 
 void Scene::createEntity(const std::string & lua_file) //provides a user-friendly function that you only need to specify the script entity to.
 {
-    entityFactory.create_from_file(bbECS, lua.getLuaState(), lua_file);
+    entityFactory.create_from_file(bbECS, lua.getLuaState(), lua_file, resources);
 }
 
 void Scene::createEntityAndTransform(const std::string & lua_file, float xPos, float yPos, float zPos)
 {
-    entityFactory.create_from_file(bbECS, lua.getLuaState(), lua_file, xPos, yPos, zPos);
+    entityFactory.create_from_file(bbECS, lua.getLuaState(),lua_file, resources, xPos, yPos, zPos);
+}
+
+const float Scene::getTerrainHeight(float x, float z)
+{
+    return Systems::getTerrainHeight(bbECS, resources.getSceneTerrain(), x, z).value();
 }
 
 Scene::Scene(const std::string& lua_master, float screenwidth, float screenheight)
@@ -106,6 +111,7 @@ Scene::Scene(const std::string& lua_master, float screenwidth, float screenheigh
     masterLuaFile = lua_master;
     lua.getLuaState().set_function("create_entity", &Scene::createEntity, this); //register create entity function into lua state of this instance
     lua.getLuaState().set_function("create_entityTR", &Scene::createEntityAndTransform, this);
+    lua.getLuaState().set_function("getTerrainHeight", &Scene::getTerrainHeight, this); //alows the user to fetch terrain height script-side for easy object placement
 
     init();
 
@@ -179,9 +185,6 @@ void Scene::init()
         return;
     }//load the master lua scene script containing all entities
 
-    bbSystems.createTerrainComponents(bbECS, resources.getSceneTerrain());
-    bbSystems.createModelComponents(bbECS, resources.getSceneModels());
-    bbSystems.createMD2ModelComponents(bbECS, resources.getSceneMD2Models());
     initBBGUI(window.GetContext());
 }
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -176,7 +176,7 @@ void Scene::init()
     mainCamera.SetPosition(1000.0f, 100.0f, 1000.0f);
     mainCamera.SetSensitivity(0.05f);
     mainCamera.SetSpeed(1000.0f);
-    mainCamera.SetZoom(30.0f);
+    mainCamera.SetZoom(45.0f);
 
     bbSystems.RegisterAIFunctions(bbECS, lua.getLuaState(), mainCamera); // register functions before running scripts
     if(!lua.getLuaState().do_file(masterLuaFile).valid())

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.h
@@ -85,6 +85,13 @@ class Scene
     void createEntityAndTransform(const std::string & lua_file, float xPos, float yPos, float zPos);
 
     /**
+    * Gets the terrain height at a specified x and z value (used in scripts)
+    * @param x X position of specified item
+    * @param z Z position of specified item
+    */
+    const float getTerrainHeight(float x, float z);
+
+    /**
      *
      * @param shaderType
      * @param vertexSource

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/master_file.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/master_file.lua
@@ -7,17 +7,17 @@ create_entity("Game/NPCs/Patroller1.lua");
 create_entity("Game/NPCs/Patroller2.lua");
 create_entity("Game/NPCs/Idler1.lua");
 
-create_entity("Game/MD2Models/doomguy.lua");
+--create_entity("Game/MD2Models/doomguy.lua");
 
-for start=0, 400, 100 do
-    for start1=0, 400, 100 do
-        create_entityTR("Game/PineTree.lua", start, 0, start1); --Create a grid of 16 instances
+for start=0, 4000, 1000 do
+    for start1=0, 4000, 1000 do
+        create_entityTR("Game/PineTree.lua", start, getTerrainHeight(start, start1), start1); --Create a grid of 16 instances
     end
 end
 
-for start=0, 400, 100 do
-    for start1=0, 300, 100 do
-        create_entityTR("Game/House.lua", start, 0, start1); --Create a grid of 12 instances
+for start=0, 4000, 1000 do
+    for start1=0, 3000, 1000 do
+       create_entityTR("Game/House.lua", start, getTerrainHeight(start,start1), start1); --Create a grid of 12 instances
     end
 end
 


### PR DESCRIPTION
## What problem does this pull request address?
<!-- Give a summary of the problem being fixed or the enhancement being implemented. Tag the issue or task wherever possible. -->

This addresses the issue of needing to be able to fetch terrain height from a scene lua script so that we can initialize any models in the scene to a terrain height.

## How does this pull request solve the problem?
<!-- Give a summary of the solution being implemented and any details that will help the reviewer understand the changes. Explain why you chose this approach and any relevant design decisions you made. Are there any consequences beyond the scope of the problem being addressed? -->

This feature was achieved by removing all of the component-based object generation function from the System namespace, and instead, entities now get pushed to their relevant resource manager containers in the scope where their entity is constructed. This works as transform components are *always* created first, so anything that needs to be constructed with transforms before being pushed into a resource management container will be handled accordingly.

This needed to be done as the `getTerrainHeight` function we're registering for lua scripting required to access initialized instances of the terrain data, which before was not possible due to how we were initializing the resource maps (they were initialized *after* the `master_file` lua script was executed, so the script was trying to query non-existent data before it was initalized.

This addition fixes this initalization problem. The additional benefit of this inegration is also the de-clutering of the `Systems` namespace by removing unecessary component generation functions, but it now also allows the user to directly query scene instance data in scripting through any future lua functions we register.

The `getTerrainHeight` function is implemented by having a System function that queries all terrain components in the scene ECS and then returns a valid height value based on `x` and `z` values passed into it. It will default to `std::nullopt` if no valid height value is returned by this function. This function is then wrapped into another function in the `Scene` class so that a simplified version that only takes 2 floats can be registered to the lua state. This registered function is inteded to be used by the user to query terrain height in scripts.

Additionally, the camera FOV (cameraZoom) was updated in this PR so that the viewport wouldn't feel so restrictive and feel nice to move around the scene.

## Using the getTerrainHeight() 

Here is an example of using the terrain height on a pine tree in a lua script. This code creates a grid of pine trees, with a `y` transform offset at the return value of `getTerrainHeight()`

```lua
for start=0, 4000, 1000 do
    for start1=0, 4000, 1000 do
        create_entityTR("Game/PineTree.lua", start, getTerrainHeight(start, start1), start1); --Create a grid of 16 instances
    end
end
```

## Demo

https://github.com/Minywire/Bottlebrush_Engine/assets/77040582/cc6ce579-4fa2-4820-8c5e-64b8794c56de


## What testing has been performed?
<!-- Use checkboxes to list tests from your test plan and check them off as they are completed. -->
<!-- If applicable, explain which tests will be done after the pull request is merged. -->
<!-- If no testing is done or applicable, please describe your rationale behind it. -->

- [x] Builds successfully
- [x] Objects get placed in the correct terrain height based on their specified x and z positions.
- [x] Runs successfully
