### PR TITLE
AI Script Read Refactor

### DIFF
--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.cpp
@@ -5,15 +5,16 @@
 #include "FSM.h"
 #include "NPC.h"
 
-FSM::FSM(NPC* FSMOwner, const std::filesystem::path& statesPath, const std::string& initialState) : 
+FSM::FSM(NPC* FSMOwner, const std::filesystem::path& statesPath,
+         const std::string& initialState, const std::string& globalState)
+    : 
     m_npcReference(FSMOwner),
-    m_currentState(initialState),
-    m_globalState("Global"),
-    m_previousState(initialState) 
+    m_statePath(statesPath),
+    m_previousState(initialState),
+    m_globalState(globalState),
+    m_currentState(initialState)
 {
-    SetStatePath(statesPath);
-    std::cout << "State Path: " << statesPath.string() << std::endl;  //@Debug Line, to be removed
-    std::cout << "Initial State: " << initialState << std::endl;  //@Debug Line, to be removed
+
 }
 
 void FSM::update(sol::state & lua_state)
@@ -45,17 +46,11 @@ void FSM::ChangeState(const std::string& newState, sol::state& lua_state)
         "AI state: " + newState + " not found on change state method";
     throw std::runtime_error(errMsg);
     }
-
+    
     m_previousState = m_currentState;                      // track previous state
     lua_state[m_currentState]["onExit"](*m_npcReference);    // execute exit code
     m_currentState = newState;                             // change states
     lua_state[m_currentState]["onEnter"](*m_npcReference);  // execute enter code of new state
-}
-
-void FSM::SetStatePath(const std::filesystem::path& path)
-{
-    if(path.extension() != ".lua") { throw std::runtime_error("Lua file is no lua file"); }
-    m_statePath = path;
 }
 
 std::filesystem::path& FSM::GetStatePath() 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/FSM.h
@@ -18,7 +18,7 @@ class NPC;
 class FSM
 {
 public:
-    FSM(NPC* FSMOwner, const std::filesystem::path& statesPath, const std::string& initialState);
+    FSM(NPC* FSMOwner, const std::filesystem::path& statesPath, const std::string& initialState, const std::string& globalState);
 
     /// @author Alan
     /// @brief normal update call for state machine
@@ -32,11 +32,6 @@ public:
     /// @param newState the new state to transition to
     /// @param lua_state used to reference to the next section of the script to run
     void ChangeState(const std::string& newState, sol::state& lua_state);
-
-    /// @author Alan
-    /// @brief evaluate if path extension is correct and then sets the member statePath its value
-    /// @param path the string to get the ai script
-    void SetStatePath(const std::filesystem::path& path);
 
     std::filesystem::path& GetStatePath();
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.cpp
@@ -12,8 +12,9 @@
 #include "Singleton.h"
 
 NPC::NPC(const std::filesystem::path& statesPath,
-         const std::string& initialState, Entity& entity)
-    : m_FSM(this, statesPath, initialState), 
+         const std::string& initialState, const std::string& globalState,
+         Entity& entity)
+    : m_FSM(this, statesPath, initialState, globalState), 
     m_DeltaTime(0.f),
     m_Entity(entity),
     m_CurrentWaypoint(0),
@@ -78,7 +79,7 @@ void NPC::Wander(ECS& ecs)
 
     // this behavior is dependent on the update rate, so this line
     // must be included when using time independent frame rate.
-    double jitterThisTimeSlice = m_WanderJitter * m_DeltaTime;
+    float jitterThisTimeSlice = m_WanderJitter * m_DeltaTime;
     // first, add a small random vector to the target's position
     m_WanderTarget += glm::vec2(randNum * jitterThisTimeSlice, randNum * jitterThisTimeSlice);
     // reproject this new vector back on to a unit circle

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBAI/NPC.h
@@ -18,7 +18,7 @@ class ECS;
 class NPC 
 {
 public:
-    NPC(const std::filesystem::path& statesPath, const std::string& initialState, Entity& entity);
+    NPC(const std::filesystem::path& statesPath, const std::string& initialState, const std::string& globalState, Entity& entity);
     
     /// @author Alan
     /// @brief update call for FSM

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Components.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Components.h
@@ -62,8 +62,8 @@ struct AIControllerComponent
     NPC npc;
 
     AIControllerComponent(const std::filesystem::path& statesPath, const std::string& initialState,
-                          Entity& entity)
-        : npc(NPC(statesPath, initialState, entity))
+        const std::string& globalState, Entity& entity)
+        : npc(NPC(statesPath, initialState, globalState, entity))
     {}
 };
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/EntityFactory.h
@@ -89,8 +89,9 @@ private:
      * @param ecs the ecs registry to load model component from
      * @param entity the entity to attach to
      * @param ai the ai table to compare against
+     * @param resources The resource interface containing all resource containers
      */
-    void loadAIController(ECS &ecs, Entity &entity, const sol::table &ai);
+    void loadAIController(ECS &ecs, Entity &entity, const sol::table &ai, BBResourceManager& resources);
 
     /**
     *  @param ecs the ecs registry to load model component from

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -214,10 +214,9 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
 void Systems::updateAI(ECS& ecs, sol::state& lua_state, float deltaTime) {
     auto group = ecs.GetAllEntitiesWith<AIControllerComponent>();
 
-    for (auto entity : group)
+    for (auto& entity : group)
     {
       auto& aic = group.get<AIControllerComponent>(entity);
-      lua_state.script_file(aic.npc.GetFSM().GetStatePath().string());
 
       aic.npc.Update(lua_state, deltaTime);
     }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.cpp
@@ -33,6 +33,10 @@ void Systems::setLight(RenderEngine & renderEngine, const ShaderType & shaderTyp
 
 void Systems::drawModels(const ECS &ecs, const ShaderType & shaderType, RenderEngine & renderEngine, const std::unordered_map<std::string, std::unique_ptr<Model>> & sceneModels, glm::mat4 projection, glm::mat4 view)
 {
+    // set static uniforms
+    renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("projection", projection);
+    renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("view", view);
+
     auto group = ecs.GetAllEntitiesWith<ModelComponent, TransformComponent>(); //the container with all the matching entities
 
     for(auto entity : group)
@@ -50,8 +54,6 @@ void Systems::drawModels(const ECS &ecs, const ShaderType & shaderType, RenderEn
         if(sceneModels.count(currentModelComponent.model_path) != 0)
         {
             //set uniforms for model
-            renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("projection", projection);
-            renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("view", view);
             renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("model", transform);
 
             //draw model
@@ -67,6 +69,11 @@ void Systems::drawModels(const ECS &ecs, const ShaderType & shaderType, RenderEn
 
 void Systems::drawMD2Models(const ECS& ecs, const ShaderType& shaderType, RenderEngine& renderEngine, std::unordered_map<std::string, BBMD2> & MD2s, glm::mat4 projection, glm::mat4 view)
 {
+    // set static uniforms
+    renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("projection", projection);
+    renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("view", view);
+    renderEngine.GetShader(shaderType)->SetUniform1i("texSampler1", 0);
+
     auto group = ecs.GetAllEntitiesWith<MD2Component, TransformComponent>();
 
     for (auto entity : group)
@@ -87,12 +94,9 @@ void Systems::drawMD2Models(const ECS& ecs, const ShaderType& shaderType, Render
         transform = glm::rotate(transform, glm::radians(-90.f), glm::vec3(0,1,0));
         transform = glm::rotate(transform, glm::radians(-90.f), glm::vec3(1,0,0));
         transform = glm::scale(transform, currentTransformComponent.scale);
-
-        renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("projection", projection);
-        renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("view", view);
+        
         renderEngine.GetShader(shaderType)->SetUniformMatrix4fv("model", transform);
         renderEngine.GetShader(shaderType)->SetUniform1f("interpolation", currentMD2Component.interpolation);
-        renderEngine.GetShader(shaderType)->SetUniform1i("texSampler1", 0);
 
         MD2Model.setTexture();
         renderEngine.Draw(shaderType, MD2Model.getVecArrays().at(currentMD2Component.current_frame), MD2Model.getModelSize());
@@ -128,6 +132,14 @@ void Systems::updateMD2Interpolation(ECS& ecs, std::unordered_map<std::string, B
 
 void Systems::drawTerrain(const ECS& ecs, const ShaderType& terrainShader, RenderEngine& renderEngine, std::unordered_map<std::string, Terrain> & sceneTerrain, bool grayscale, glm::mat4 projection, glm::mat4 view)
 {
+    // set static uniforms
+    renderEngine.GetShader(terrainShader)->SetUniformMatrix4fv("gView", view);
+    renderEngine.GetShader(terrainShader)->SetUniformMatrix4fv("gProjection", projection);
+    // set static Frag Uniforms
+    renderEngine.GetShader(terrainShader)->SetUniform1i("gGrayscale", grayscale);
+    renderEngine.GetShader(terrainShader)->SetUniform1i("gTex", 0);
+    renderEngine.GetShader(terrainShader)->SetUniform3fv("gReversedLightDir", {-0.2f, 0.7f, -0.4f});
+
     auto group = ecs.GetAllEntitiesWith<TerrainComponent, TransformComponent>(); //the container with all the matching entities
 
     for(auto entity : group)
@@ -143,22 +155,12 @@ void Systems::drawTerrain(const ECS& ecs, const ShaderType& terrainShader, Rende
         // Vert Uniforms
         renderEngine.GetShader(terrainShader)
             ->SetUniformMatrix4fv("gModel", transform);
-        renderEngine.GetShader(terrainShader)
-            ->SetUniformMatrix4fv("gView", view);
-        renderEngine.GetShader(terrainShader)
-            ->SetUniformMatrix4fv("gProjection", projection);
+        
         renderEngine.GetShader(terrainShader)
             ->SetUniform1f("gMinHeight", terrain.GetMinHeight());
         renderEngine.GetShader(terrainShader)
             ->SetUniform1f("gMaxHeight", terrain.GetMaxHeight());
-
-        // Frag Uniforms
-        renderEngine.GetShader(terrainShader)
-            ->SetUniform1i("gGrayscale", grayscale);
-        renderEngine.GetShader(terrainShader)->SetUniform1i("gTex", 0);
-        renderEngine.GetShader(terrainShader)
-            ->SetUniform3fv("gReversedLightDir", {-0.2f, 0.7f, -0.4f});
-
+        
         // draw
         terrain.GetMesh()->SetTexture(0);
         renderEngine.Draw(terrainShader, *terrain.GetMesh()->GetVertexArray(),
@@ -208,7 +210,7 @@ void Systems::updateAIMovements(ECS& ecs, float deltaTime, std::unordered_map<st
             // set the new y position
             transform.position.y = heightOpt.value() + 20 * transform.scale.y; // plus an offset, should be taken out once other physics is implemented
         }
-    }
+    }   
 }
 
 void Systems::updateAI(ECS& ecs, sol::state& lua_state, float deltaTime) {

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBComponentSystem/Systems.h
@@ -101,9 +101,9 @@ public:
     /**
      * @author Alan
      * @brief update AI call
-     * @param sceneNPCs vector of all npcs to iterate through
+     * @param ecs registry of all npcs to iterate through
      * @param lua_state AI script to read for FSM in NPCs
-     * @param AIUpdateIntervalTime this is the time representing the time for the ai to be called
+     * @param deltaTime this is the time representing the time for the ai to be called
      */
     static void updateAI(ECS &ecs, sol::state &lua_state, float deltaTime);
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBResourceManager/BBResourceManager.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBResourceManager/BBResourceManager.cpp
@@ -33,3 +33,13 @@ std::unordered_map<std::string, BBMD2> & BBResourceManager::getSceneMD2Models()
 {
     return sceneMD2Models;
 }
+
+const std::unordered_set<std::string>& BBResourceManager::getSceneAIStates() const
+{
+    return sceneAIStates;
+}
+
+std::unordered_set<std::string>& BBResourceManager::getSceneAIStates()
+{
+    return sceneAIStates;
+}

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBResourceManager/BBResourceManager.hpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBResourceManager/BBResourceManager.hpp
@@ -7,6 +7,7 @@
 #include "GraphicsFactory.h"
 #include "Terrain.h"
 #include <unordered_map>
+#include <unordered_set>
 #include <BBMD2.h>
 /**
  * @class BBResourceManager
@@ -48,10 +49,15 @@ public:
      */
     std::unordered_map<std::string, BBMD2>& getSceneMD2Models();
 
+    const std::unordered_set<std::string>& getSceneAIStates() const;
+    std::unordered_set<std::string>& getSceneAIStates();
+
 private:
     std::unordered_map<std::string, std::unique_ptr<Model>> sceneModels; ///The models stored in a scene
 
     std::unordered_map <std::string, BBMD2> sceneMD2Models; //The MD2 models stored in a scene
 
     std::unordered_map<std::string, Terrain> sceneTerrain; //The terrain stored in a scene
+
+    std::unordered_set<std::string> sceneAIStates; // AI states in lua
 };

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScene/Scene.cpp
@@ -194,6 +194,12 @@ void Scene::init()
         return;
     }//load the master lua scene script containing all entities
 
+    // read all ai scripts
+    for (auto& aiStates : resources.getSceneAIStates()) 
+    {
+        lua.getLuaState().script_file(aiStates);
+    }
+
     initBBGUI(window.GetContext());
 }
 

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -76,7 +76,10 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player, 
 
     // register game mechanics table functions
     auto gameTable = lua_state["Game"].get_or_create<sol::table>();
-    gameTable["GameOver"] = [&endGame]() { /*endGame = true;*/ };
+    gameTable["GameOver"] = [&endGame]()
+    {
+        //endGame = true;
+    };
 }
 
 void registerScriptedGLM(sol::state& lua_state) {

--- a/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/BBScript/RegisterAIScripts.cpp
@@ -76,7 +76,7 @@ void registerScriptedNPC(sol::state& lua_state, ECS& ecs, const Camera& player, 
 
     // register game mechanics table functions
     auto gameTable = lua_state["Game"].get_or_create<sol::table>();
-    gameTable["GameOver"] = [&endGame]() { endGame = true; };
+    gameTable["GameOver"] = [&endGame]() { /*endGame = true;*/ };
 }
 
 void registerScriptedGLM(sol::state& lua_state) {

--- a/Bottlebrush_Engine/Bottlebrush_Engine/EntryPoint.cpp
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/EntryPoint.cpp
@@ -1,20 +1,9 @@
 ﻿#define GLM_ENABLE_EXPERIMENTAL
 
-#include <iostream>
-
-#include "Camera.h"
-#include "GraphicsFactory.h"
 #include "Scene.h"
-#include "Skybox.h"
-#include "Terrain.h"
-#include "Window.h"
-#include "glad/glad.h"
-#include "glfw/glfw3.h"
-#include "glm/glm.hpp"
-#include "glm/gtc/matrix_transform.hpp"
 
 int main() {
     Scene gameScene("Game/master_file.lua", 1920, 1080);
     gameScene.update();
-  return 0;
+    return 0;
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/WanderStates.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/AIStates/WanderStates.lua
@@ -23,7 +23,7 @@ end
 -- create the global state
 
 -------------------------------------------------------------------------------
-Global = {
+WandererGlobal = {
 	onEnter = function(NPC)
 		
 	end,
@@ -46,7 +46,7 @@ Global = {
 -- create the idle state
 
 -------------------------------------------------------------------------------
-Idle = {
+WandererIdle = {
 	onEnter = function(NPC)
 		NPC:StopMoving();
 		NPC:SetWaitDuration(5.0);
@@ -54,11 +54,11 @@ Idle = {
 
 	Update = function(NPC)
 		if not NPC:IsWaiting() then 
-			FSM.ChangeState(NPC, "Wander");
+			FSM.ChangeState(NPC, "WandererWander");
 		end
 		if Detection.SeePlayer(NPC, 1000.0, 160.0) then
 			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
-			FSM.ChangeState(NPC, "Chase");
+			FSM.ChangeState(NPC, "WandererChase");
 		end	
 	end,
 
@@ -70,7 +70,7 @@ Idle = {
 		if Dispatch.InMessageRange(NPC, Message, 2000.0) then
 			if Message.Event == "PlayerSpotted" then
 				Movement.MoveTo(NPC, Dispatch.GetVec2SenderLocation(Message))
-				FSM.ChangeState(NPC, "Investigate");
+				FSM.ChangeState(NPC, "WandererInvestigate");
 			end
 		end
 	end
@@ -81,7 +81,7 @@ Idle = {
 -- create the Wander state
 
 -------------------------------------------------------------------------------
-Wander = {
+WandererWander = {
 	onEnter = function(NPC)
 		NPC:SetWander(200.0, 300.0, 50.0);
 		Movement.Wander(NPC);
@@ -96,7 +96,7 @@ Wander = {
 		end
 		if Detection.SeePlayer(NPC, 1000.0, 160.0) then
 			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
-			FSM.ChangeState(NPC, "Chase");
+			FSM.ChangeState(NPC, "WandererChase");
 		end	
 	end,
 
@@ -108,7 +108,7 @@ Wander = {
 		if Dispatch.InMessageRange(NPC, Message, 1000.0) then
 			if Message.Event == "PlayerSpotted" then
 				Movement.MoveTo(NPC, Dispatch.GetVec2SenderLocation(Message))
-				FSM.ChangeState(NPC, "Investigate");
+				FSM.ChangeState(NPC, "WandererInvestigate");
 			end
 		end
 	end
@@ -119,9 +119,10 @@ Wander = {
 -- create the chase state
 
 -------------------------------------------------------------------------------
-Chase = {
+WandererChase = {
 	onEnter = function(NPC)
 		Movement.ChasePlayer(NPC);
+		
 	end,
 
 	Update = function(NPC)
@@ -129,15 +130,15 @@ Chase = {
         if Detection.SeePlayer(NPC, 1000.0, 160.0) then
             Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
             if not Movement.ChasePlayer(NPC) then
-                FSM.ChangeState(NPC, "Attack");
+                FSM.ChangeState(NPC, "WandererAttack");
             end
         elseif not Detection.SeePlayer(NPC, 1000.0, 160.0) and not NPC:IsMoving() then
-            FSM.ChangeState(NPC, "Idle");
+            FSM.ChangeState(NPC, "WandererIdle");
         end
     end,
 
 	onExit = function(NPC)
-
+		
 	end
 }
 
@@ -146,7 +147,7 @@ Chase = {
 -- create the investigate state
 
 -------------------------------------------------------------------------------
-Investigate = {
+WandererInvestigate = {
 	onEnter = function(NPC)
 		
 	end,
@@ -155,9 +156,9 @@ Investigate = {
 		Movement.MoveTo(NPC, NPC:GetLastMoveTo());
 		if Detection.SeePlayer(NPC, 1000.0, 160.0) then
 			Dispatch.SendMessage("PlayerSpotted", NPC, 3.0);
-			FSM.ChangeState(NPC, "Chase");
+			FSM.ChangeState(NPC, "WandererChase");
 		elseif not Detection.SeePlayer(NPC, 1000.0, 160.0) and not NPC:IsMoving() then
-			FSM.ChangeState(NPC, "Idle");
+			FSM.ChangeState(NPC, "WandererIdle");
 		end
 	end,
 
@@ -179,16 +180,19 @@ Investigate = {
 -- create the attack state
 
 -------------------------------------------------------------------------------
-Attack = {
+WandererAttack = {
     onEnter = function(NPC)
         Animation.SetAnimation(NPC, "attack");
     end,
 
     Update = function(NPC)
         Game.GameOver();
+		if Movement.ChasePlayer(NPC) then
+            FSM.ChangeState(NPC, "WandererChase");
+        end
     end,
 
     onExit = function(NPC)
-
+		Animation.SetAnimation(NPC, "run");
     end,
 }

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Idler1.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Idler1.lua
@@ -2,7 +2,7 @@ Entity = {
     Transform = {
         Position = {
             x = 600,
-            y = 40,
+            y = 0,
             z = 500
         },
         Rotation = {
@@ -22,7 +22,8 @@ Entity = {
     },
     AI = {
         StatesPath = "Game/AIStates/IdlerStates.lua",
-        InitialState = "Idle"
+        InitialState = "IdlerIdle",
+        GlobalState = "IdlerGlobal"
     },
     Collider = {
         Type = 0,

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Patroller1.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Patroller1.lua
@@ -22,7 +22,8 @@ Entity = {
     },
     AI = {
         StatesPath = "Game/AIStates/PatrollerStates.lua",
-        InitialState = "Idle",
+        InitialState = "PatrollerIdle",
+        GlobalState = "PatrollerGlobal",
         Waypoints = {vec2(41500, 42500), vec2(42300, 42000), vec2(44000, 41000)}
     },
     Collider = {

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Patroller2.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Patroller2.lua
@@ -22,7 +22,8 @@ Entity = {
     },
     AI = {
         StatesPath = "Game/AIStates/PatrollerStates.lua",
-        InitialState = "Idle",
+        InitialState = "PatrollerIdle",
+        GlobalState = "PatrollerGlobal",
         Waypoints = {vec2(44100, 41500), vec2(42500, 44600)}
     },
     Collider = {

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Wanderer1.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/NPCs/Wanderer1.lua
@@ -1,9 +1,9 @@
 Entity = {
     Transform = {
         Position = {
-            x = 700,
-            y = 40,
-            z = 500
+            x = 0,
+            y = 0,
+            z = 0
         },
         Rotation = {
             x = 0,
@@ -22,7 +22,8 @@ Entity = {
     },
     AI = {
         StatesPath = "Game/AIStates/WanderStates.lua",
-        InitialState = "Idle"
+        InitialState = "WandererIdle",
+        GlobalState = "WandererGlobal"
     },
     Collider = {
         Type = 0,

--- a/Bottlebrush_Engine/Bottlebrush_Engine/Game/master_file.lua
+++ b/Bottlebrush_Engine/Bottlebrush_Engine/Game/master_file.lua
@@ -3,8 +3,8 @@ math.randomseed(os.time())
 
 -- Globals
 local CENTRE = 40960
-local NUM_TREES = 200
-local NUM_HOUSE = 5
+local NUM_TREES = 1200
+local NUM_HOUSE = 20
 local NUM_WANDERER = 20
 local NUM_IDLER = 10
 local NUM_PATROLLER = 5


### PR DESCRIPTION
## What problem does this pull request address?
Reading AI scripts on update seemed to dip performance. This PR also changes a few performance issues.

## How does this pull request solve the problem?
Changing each of the states to be unique within the lua files. That way then they can be loaded once on init to avoid reading it every AI tick.

Moved a few Shader bind calls for values that does not change throughout each entity loop in models. This was just an uneccessary bind to do for every entity since those values do not change. Such as view and projection matrixes, and texSamplers.

## What testing has been performed?

- [x] Added more objects, trees and houses to check if performance doesn't dip.
- [x] Builds successfully
- [x] Runs successfully
